### PR TITLE
fix breakages from turnstile one-env commit

### DIFF
--- a/hackett-lib/hackett/private/type.rkt
+++ b/hackett-lib/hackett/private/type.rkt
@@ -6,7 +6,7 @@
          (for-template (prefix-in kernel: '#%kernel)
                        racket/base
                        (only-in macrotypes/typecheck
-                                get-stx-prop/car
+                                typeof
                                 set-stx-prop/preserved))
          (multi-in hackett/private/util [function stx])
          (multi-in racket [dict format list match syntax])
@@ -120,9 +120,6 @@
     [(τapp τa τb) (remove-duplicates (append (type-free-vars τa)
                                              (type-free-vars τb))
                                      free-identifier=?)]))
-
-(define (typeof stx)
-  (get-stx-prop/car stx ':))
 
 (define (assign-type stx τ)
   (match τ
@@ -587,7 +584,7 @@
 (define (apply-substitutions-to-types subst stx)
   (define (perform-substitution/: stx)
     (if (syntax-property stx ':)
-        (let ([new-type (apply-subst subst (get-stx-prop/car stx ':))])
+        (let ([new-type (apply-subst subst (typeof stx))])
           (syntax-property (syntax-property stx ': new-type #t)
                            ':-string (type->string new-type)))
         stx))


### PR DESCRIPTION
Don't merge this yet, but I'm about to make a large breaking commit to Turnstile and this PR will fix the breakages.

In summary, the commit:

- separates handling of types, kinds, etc
I was reusing "type" functions for manipulating kinds and other metadata and this is problematic when trying to implement more complicated systems like F_omega. The upcoming commit uses a different key for the kind stx prop and gives kinds its own separate api. So for example, to define a kind rule, you use `define-kinded-syntax`, which properly calls the kind api. Before, it was reusing the type functions, which was bad if you wanted them to have different behaviors, eg separate `type=` and `kind=` functions.

- generalizes the type environment
The environment now works with arbitrary key-values, and also has a "let*" semantics where each binding is in scope for subsequent bindings. This means only one environment is needed, eg type and term variables can be mixed (so long as their are in the right order if there are dependencies).