### PR TITLE
Use current print

### DIFF
--- a/hackett-doc/scribblings/hackett/guide.scrbl
+++ b/hackett-doc/scribblings/hackett/guide.scrbl
@@ -51,8 +51,8 @@ The above expressions were very simple, just simple constants, so they are immed
 without any additional evaluation. Calling some functions is slightly more interesting:
 
 @(hackett-interaction
-  (+ 1 2)
-  (not true))
+  (eval:check (+ 1 2) 3)
+  (eval:check (not true) false))
 
 In Hackett, like any other Lisp, function calls are syntactically represented by surrounding
 subexpressions with parentheses. In any expression @racket[(_f _x _y _z)], @racket[_f] is a function
@@ -109,7 +109,7 @@ be able to write your own definitions. A binding can be defined with the @racket
 
 @(hackett-interaction
   (def x 5)
-  (* x x))
+  (eval:check (* x x) 25))
 
 All bindings in Hackett are immutable: once something has been defined, its value cannot be changed.
 This may sound like a severe limitation, but it is not as austere as you might think. In practice, it
@@ -130,7 +130,7 @@ This can be accomplished using the similar @racket[defn] form:
   #:eval square-no-sig-eval
   (defn square
     [[x] (* x x)])
-  (square 5))
+  (eval:check (square 5) 25))
 
 This defines a one-argument function called @racket[square], which (unsurprisingly) squares its
 argument. Notably, we did not provide a type signature for @racket[square], but its type was still
@@ -152,7 +152,7 @@ It’s possible to add a type signature to any definition by placing a type anno
 @(hackett-interaction
   (defn square : (-> Integer Integer)
     [[x] (* x x)])
-  (square 5))
+  (eval:check (square 5) 25))
 
 This definition is equivalent to the previous definition of @racket[square], but its type is validated
 by the typechecker. If a type annotation is provided, but the expression does not actually have the

--- a/hackett-doc/scribblings/hackett/private/util.rkt
+++ b/hackett-doc/scribblings/hackett/private/util.rkt
@@ -21,13 +21,13 @@
 ;; ---------------------------------------------------------------------------------------------------
 ;; evaluation
 
-(define (make-hackett-eval [body '()])
+(define (make-hackett-eval)
   (parameterize ([sandbox-output 'string]
                  [sandbox-error-output 'string])
-    (make-module-evaluator
-     #:language 'hackett
-     `(module m hackett
-        ,@body))))
+    ; Evaluators produced by racket/sandbox do not automatically require the configure-runtime
+    ; submodule of the specified language, so we need to load it explicitly in order to set up the
+    ; custom printer.
+    (make-evaluator 'hackett #:requires '((submod hackett configure-runtime)))))
 
 (define-simple-macro (hackett-examples
                       {~or {~optional {~seq #:eval eval:expr}}

--- a/hackett-doc/scribblings/hackett/reference.scrbl
+++ b/hackett-doc/scribblings/hackett/reference.scrbl
@@ -63,7 +63,7 @@ inferred from @racket[val-expr].
 
 @(hackett-examples
   (def x 7)
-  x
+  (eval:check x 7)
   (def y : Integer 7)
   (eval:error (def z : String 7)))}
 
@@ -88,7 +88,7 @@ The @racket[defn] form is generally preferred when defining top-level functions.
 @(hackett-examples
   (defn square : (-> Integer Integer)
     [[x] (* x x)])
-  (square 5))}
+  (eval:check (square 5) 25))}
 
 @subsection[#:tag "reference-anonymous-functions"]{Anonymous Functions}
 
@@ -101,7 +101,7 @@ number of @racket[arg-pat]s provided. When the function is applied, the provided
 matched against each @racket[arg-pat], and the function’s result will be @racket[body-expr].
 
 @(hackett-examples
-  ((λ [x y] (+ x (* y 2))) 5 10))}
+  (eval:check ((λ [x y] (+ x (* y 2))) 5 10) 25))}
 
 @deftogether[
  [@defform[(lambda* [[arg-pat ...+] body-expr] ...+)]
@@ -116,9 +116,10 @@ combination of @racket[lambda] and @racket[case*]:
       [[arg-pat ...] body-expr] ...)))
 
 @(hackett-examples
-  ((λ* [[(just x)] x]
-       [[nothing] 0])
-   (just 42)))}
+  (eval:check ((λ* [[(just x)] x]
+                   [[nothing] 0])
+               (just 42))
+              42))}
 
 @subsection[#:tag "reference-pattern-matching"]{Pattern Matching}
 
@@ -129,9 +130,10 @@ Matches @racket[val-expr] against each @racket[pat], in order. The result of the
 result of the @racket[body-expr] for the first matching @racket[pat].
 
 @(hackett-examples
-  (case (just 42)
-    [(just x) x]
-    [nothing 0]))}
+  (eval:check (case (just 42)
+                [(just x) x]
+                [nothing 0])
+              42))}
 
 @defform[(case* [val-expr ...+]
            [[pat ...+] body-expr] ...+)]{
@@ -140,11 +142,12 @@ Like @racket[case], but matches against multiple values at once. Each case only 
 @racket[pat]s succeed.
 
 @(hackett-examples
-  (case* [(just 1) (just 2)]
-         [[(just _) nothing] "first"]
-         [[nothing (just _)] "second"]
-         [[(just _) (just _)] "both"]
-         [[nothing nothing] "neither"]))}
+  (eval:check (case* [(just 1) (just 2)]
+                [[(just _) nothing] "first"]
+                [[nothing (just _)] "second"]
+                [[(just _) (just _)] "both"]
+                [[nothing nothing] "neither"])
+              "both"))}
 
 @section[#:tag "reference-datatypes"]{Datatypes}
 
@@ -252,8 +255,8 @@ The identity function. Returns its argument unchanged.}
 Accepts two arguments and returns the first, ignoring the second.
 
 @(hackett-examples
-  (const "hello" "goodbye")
-  (const unit (error! "never gets here")))}
+  (eval:check (const "hello" "goodbye") "hello")
+  (eval:check (const unit (error! "never gets here")) unit))}
 
 @subsection[#:tag "reference-quantification"]{Quantification and Constrained Types}
 

--- a/hackett-lib/hackett/main.rkt
+++ b/hackett-lib/hackett/main.rkt
@@ -1,6 +1,22 @@
-#lang racket/base
+#lang hackett/private/kernel
 
-(require hackett/prelude
+; This module needs to be written in #lang hackett/private/kernel (or any #lang that provides
+; hackett/private/kernel’s #%module-begin) so that it includes the configure-runtime submodule that
+; sets up current-print. This is necessary, since the -I flag provided to the racket executable loads
+; the configure-runtime submodule present in the specified <init-lib>, and it completely ignores the
+; #%module-begin *exported* by <init-lib>.
+;
+; This is different from the REPL in DrRacket, which takes a different approach to initializing the
+; namespace. It effectively uses the contents of the definitions window to create a module that can be
+; provided to module->namespace, and it uses the configure-runtime submodule of the module in the
+; definitions window, *not* the configure-runtime submodule of the #lang or module language used. This
+; means that #%module-begin *is* relevant in DrRacket, which is generally the more intuitive and
+; useful approach, but the top level initialization performed by the racket excutable does not create
+; a fresh module (it merely requires the library into the top level namespace).
+
+(require (only-in racket/base all-from-out module)
+
+         hackett/prelude
          (only-in hackett/private/adt case* case λ λ* lambda lambda* defn _)
          (only-in hackett/private/class instance)
          (except-in hackett/private/kernel λ lambda)

--- a/hackett-lib/hackett/private/base.rkt
+++ b/hackett-lib/hackett/private/base.rkt
@@ -20,7 +20,7 @@
 (provide (for-syntax (all-from-out hackett/private/typecheck)
                      τ⇐/λ! τ⇐! τ⇒/λ! τ⇒! τ⇒app! τs⇒! elaborate-dictionaries)
          #%module-begin #%top
-         (rename-out [#%module-begin @%module-begin]
+         (rename-out [#%plain-module-begin @%module-begin]
                      [#%top @%top]
                      [∀ forall])
          @%datum @%app @%superclasses-key @%dictionary-placeholder @%with-dictionary

--- a/hackett-lib/hackett/private/kernel.rkt
+++ b/hackett-lib/hackett/private/kernel.rkt
@@ -7,6 +7,7 @@
          syntax/parse/define
 
          (rename-in hackett/private/base
+                    [@%module-begin @%module-begin/nonconfigured]
                     [@%app @%app1]
                     [∀ ∀1]
                     [=> =>1])
@@ -26,6 +27,13 @@
 (module reader syntax/module-reader hackett/private/kernel
   #:wrapper1 call-with-hackett-reading-parameterization
   (require hackett/private/reader))
+
+(define-simple-macro (@%module-begin body ...)
+  (@%module-begin/nonconfigured
+   (module configure-runtime racket/base
+     (require (only-in hackett/private/toplevel make-hackett-print))
+     (current-print (make-hackett-print)))
+   body ...))
 
 (define-syntax-parser λ
   [(_ [x:id] e:expr)

--- a/hackett-lib/hackett/private/toplevel.rkt
+++ b/hackett-lib/hackett/private/toplevel.rkt
@@ -68,7 +68,7 @@
          racket/promise
          syntax/parse/define)
 
-(provide @%top-interaction)
+(provide @%top-interaction make-hackett-print)
 
 (struct repl-result [value type])
 
@@ -91,13 +91,11 @@
                   ((λ (type) #`(repl-result (force expr) '#,type))))
           #'expr)])])
 
-(define print-value (current-print))
-(define (print-type-and-value y)
+(define ((make-hackett-print #:printer [orig-print (current-print)]) y)
   (match y
     [(repl-result v t)
      (begin
        (printf ": ~a\n" t)
-       (print-value v))]
+       (orig-print v))]
     [_
-     (print-value y)]))
-(current-print print-type-and-value)
+     (orig-print y)]))

--- a/hackett-lib/hackett/private/toplevel.rkt
+++ b/hackett-lib/hackett/private/toplevel.rkt
@@ -1,4 +1,4 @@
-#lang racket/base
+#lang curly-fn racket/base
 
 ; This module implements #%top-interaction for the Hackett REPL. It does some tricks to make Hackett
 ; forms cooperate more nicely with the top level while still being able to do things like print the
@@ -64,10 +64,13 @@
                      threading
 
                      hackett/private/typecheck)
+         racket/match
          racket/promise
          syntax/parse/define)
 
 (provide @%top-interaction)
+
+(struct repl-result [value type])
 
 (define-syntax-parser @%top-interaction
   [(_ . form)
@@ -82,8 +85,19 @@
       (syntax/loc this-syntax
         (begin form ... (@%top-interaction . form*)))]
      [expr
-      (and~>> (get-type #'expr)
-              apply-current-subst
-              τ->string
-              (printf ": ~a\n"))
-      #'(force expr)])])
+      (or (and~>> (get-type #'expr)
+                  apply-current-subst
+                  τ->string
+                  ((λ (type) #`(repl-result (force expr) '#,type))))
+          #'expr)])])
+
+(define print-value (current-print))
+(define (print-type-and-value y)
+  (match y
+    [(repl-result v t)
+     (begin
+       (printf ": ~a\n" t)
+       (print-value v))]
+    [_
+     (print-value y)]))
+(current-print print-type-and-value)


### PR DESCRIPTION
This reverts commit c49ec6fab882923c9cb8388aedae0712e554325d's removal of `eval-check` forms and fixes the duplicate type signatures which they used to produce.

The duplicate type signatures were caused by `#%top-interaction`, which was called by `eval-check` twice and printed a type signature each time. The proposed fix is to remove the call to `printf`, and to instead return a value describing both the result of the expression and its type. A custom printer installed on the `current-print` parameter then receives this value and prints both the type and the value.

This new `current-print` is used both by the repl and by scribble, but currently has no visible effect on the repl. It does, however, have a few unintended consequences on the documentation.

One consequence is a color change. The color of the `: type` line used to be different from the color of the output value, but now they are the same color. This is unfortunate, but I think this is for the best, as I think these colors are different because scribble tries to distinguish the output produced as a side-effect of evaluating an expression from the result of the expression itself. So once the documentation contains examples which print to the console, we will probably be happy that this output doesn't have the same color as the ": type" line.
    
Another consequence is that the output values are now printed in a different style, for example `true` is used to be printed as `#<true>` in the repl and `(true)` in the documentation, while now it is printed as `#<true>` in both places. This is more consistent, and if we eventually change the custom printer to use the Show instances, the change will be reflected both in the repl and in the documentation.