### PR TITLE
Separate type/value namespaces

### DIFF
--- a/hackett-demo/hackett/demo/pict.rkt
+++ b/hackett-demo/hackett/demo/pict.rkt
@@ -7,37 +7,39 @@
   (provide (data Color) color-red color-green color-blue color-alpha
            white black red orange yellow green blue purple)
 
-  (data Color (color Integer Integer Integer Double))
-  (defn color-red : {Color -> Integer} [[(color x _ _ _)] x])
-  (defn color-green : {Color -> Integer} [[(color _ x _ _)] x])
-  (defn color-blue : {Color -> Integer} [[(color _ _ x _)] x])
-  (defn color-alpha : {Color -> Double} [[(color _ _ _ x)] x])
+  (data Color (Color Integer Integer Integer Double))
+  (defn color-red : {Color -> Integer} [[(Color x _ _ _)] x])
+  (defn color-green : {Color -> Integer} [[(Color _ x _ _)] x])
+  (defn color-blue : {Color -> Integer} [[(Color _ _ x _)] x])
+  (defn color-alpha : {Color -> Double} [[(Color _ _ _ x)] x])
 
-  (def white : Color (color 255 255 255 1.0))
-  (def black : Color (color 0 0 0 1.0))
-  (def red : Color (color 255 0 0 1.0))
-  (def orange : Color (color 255 165 0 1.0))
-  (def yellow : Color (color 255 255 0 1.0))
-  (def green : Color (color 0 255 0 1.0))
-  (def blue : Color (color 0 0 255 1.0))
-  (def purple : Color (color 128 0 128 1.0)))
+  (def white : Color (Color 255 255 255 1.0))
+  (def black : Color (Color 0 0 0 1.0))
+  (def red : Color (Color 255 0 0 1.0))
+  (def orange : Color (Color 255 165 0 1.0))
+  (def yellow : Color (Color 255 255 0 1.0))
+  (def green : Color (Color 0 255 0 1.0))
+  (def blue : Color (Color 0 0 255 1.0))
+  (def purple : Color (Color 128 0 128 1.0)))
 
 (module untyped racket/base
   (require hackett/private/util/require
-           (only-in hackett/private/base unmangle-types-in)
+           (only-in hackett/private/base type-out unmangle-types-in)
 
-           (prefix-in hackett: (unmangle-types-in #:no-introduce
+           (prefix-in hackett: (unmangle-types-in #:prefix t:
                                                   (combine-in hackett (submod ".." shared))))
            (postfix-in - (combine-in pict racket/base racket/draw racket/promise))
 
-           (only-in (unmangle-types-in #:no-introduce hackett) : -> Integer Double String IO Unit)
+           (only-in (unmangle-types-in #:prefix t: hackett)
+                    : t:IO t:Unit
+                    [t:-> ->] [t:Integer Integer] [t:Double Double] [t:String String])
            (only-in hackett/private/base define-base-type)
-           (only-in hackett/private/prim/type io)
+           (only-in hackett/private/prim/type IO)
            hackett/private/prim/type-provide)
 
   (define-base-type Pict)
 
-  (provide Pict
+  (provide (type-out #:no-introduce Pict)
            (typed-out
             [pict-width : {Pict -> Double}]
             [pict-height : {Pict -> Double}]
@@ -81,11 +83,11 @@
             [scale : {Double -> Pict -> Pict}]
             [scale* : {Double -> Double -> Pict -> Pict}]
 
-            [colorize : {hackett:Color -> Pict -> Pict}]
+            [colorize : {hackett:t:Color -> Pict -> Pict}]
 
             [freeze : {Pict -> Pict}]
 
-            [print-pict : {Pict -> (IO Unit)}]))
+            [print-pict : {Pict -> (t:IO t:Unit)}]))
 
   (define (Color->color% c)
     (make-color- (force- (hackett:color-red c))
@@ -143,12 +145,13 @@
   (define (freeze p) (freeze- (force- p)))
 
   (define (print-pict p)
-    (io (λ (rw)
+    (IO (λ (rw)
           (println (force- p))
-          ((hackett:tuple rw) hackett:unit)))))
+          ((hackett:Tuple rw) hackett:Unit)))))
 
 (require (submod "." shared)
          (submod "." untyped))
 
 (provide (all-from-out (submod "." shared))
-         (all-from-out (submod "." untyped)))
+         (all-from-out (submod "." untyped))
+         (type-out Color Pict))

--- a/hackett-demo/hackett/demo/pict.rkt
+++ b/hackett-demo/hackett/demo/pict.rkt
@@ -3,6 +3,7 @@
 (require (only-in racket/base all-from-out module submod))
 
 (module shared hackett
+  (#%require/only-types hackett)
   (provide (data Color) color-red color-green color-blue color-alpha
            white black red orange yellow green blue purple)
 
@@ -23,11 +24,13 @@
 
 (module untyped racket/base
   (require hackett/private/util/require
+           (only-in hackett/private/base unmangle-types-in)
 
-           (prefix-in hackett: (combine-in hackett (submod ".." shared)))
+           (prefix-in hackett: (unmangle-types-in #:no-introduce
+                                                  (combine-in hackett (submod ".." shared))))
            (postfix-in - (combine-in pict racket/base racket/draw racket/promise))
 
-           (only-in hackett : -> Integer Double String IO Unit)
+           (only-in (unmangle-types-in #:no-introduce hackett) : -> Integer Double String IO Unit)
            (only-in hackett/private/base define-base-type)
            (only-in hackett/private/prim/type io)
            hackett/private/prim/type-provide)

--- a/hackett-demo/hackett/demo/pict.rkt
+++ b/hackett-demo/hackett/demo/pict.rkt
@@ -23,8 +23,8 @@
   (def purple : Color (Color 128 0 128 1.0)))
 
 (module untyped racket/base
-  (require hackett/private/util/require
-           (only-in hackett/private/base type-out unmangle-types-in)
+  (require hackett/private/type-reqprov
+           hackett/private/util/require
 
            (prefix-in hackett: (unmangle-types-in #:prefix t:
                                                   (combine-in hackett (submod ".." shared))))

--- a/hackett-demo/hackett/demo/pict/universe.rkt
+++ b/hackett-demo/hackett/demo/pict/universe.rkt
@@ -23,8 +23,8 @@
     (me:unknown String)))
 
 (module untyped racket/base
-  (require hackett/private/util/require
-           (only-in hackett/private/base unmangle-types-in)
+  (require hackett/private/type-reqprov
+           hackett/private/util/require
 
            (prefix-in hackett: (unmangle-types-in #:prefix t:
                                                   (combine-in hackett

--- a/hackett-demo/hackett/demo/pict/universe.rkt
+++ b/hackett-demo/hackett/demo/pict/universe.rkt
@@ -3,6 +3,7 @@
 (require (only-in racket/base all-from-out for-syntax module submod))
 
 (module shared hackett
+  (#%require/only-types hackett)
   (provide (data KeyEvent) (data MouseEvent))
 
   (data KeyEvent
@@ -23,11 +24,15 @@
 
 (module untyped racket/base
   (require hackett/private/util/require
+           (only-in hackett/private/base unmangle-types-in)
 
-           (prefix-in hackett: (combine-in hackett hackett/demo/pict (submod ".." shared)))
+           (prefix-in hackett: (unmangle-types-in #:no-introduce
+                                                  (combine-in hackett
+                                                              hackett/demo/pict
+                                                              (submod ".." shared))))
            (postfix-in - (combine-in 2htdp/universe pict racket/base racket/match racket/promise))
 
-           (only-in hackett ∀ : -> Integer Double IO Unit)
+           (only-in (unmangle-types-in #:no-introduce hackett) ∀ : -> Integer Double IO Unit)
            (only-in hackett/private/prim io unsafe-run-io!)
            hackett/private/prim/type-provide
            threading)

--- a/hackett-demo/hackett/demo/pict/universe.rkt
+++ b/hackett-demo/hackett/demo/pict/universe.rkt
@@ -26,29 +26,32 @@
   (require hackett/private/util/require
            (only-in hackett/private/base unmangle-types-in)
 
-           (prefix-in hackett: (unmangle-types-in #:no-introduce
+           (prefix-in hackett: (unmangle-types-in #:prefix t:
                                                   (combine-in hackett
                                                               hackett/demo/pict
                                                               (submod ".." shared))))
            (postfix-in - (combine-in 2htdp/universe pict racket/base racket/match racket/promise))
 
-           (only-in (unmangle-types-in #:no-introduce hackett) ∀ : -> Integer Double IO Unit)
-           (only-in hackett/private/prim io unsafe-run-io!)
+           (only-in (unmangle-types-in #:prefix t: hackett)
+                    : t:IO t:Unit
+                    [t:∀ ∀] [t:-> ->] [t:Integer Integer] [t:Double Double])
+           (only-in hackett/private/prim IO unsafe-run-io!)
            hackett/private/prim/type-provide
            threading)
 
   (provide (typed-out
-            [random-integer : {Integer -> Integer -> (IO Integer)}]
-            [random-double : (IO Double)]
-            [animate : {{Integer -> hackett:Pict} -> (IO Unit)}]
-            [big-bang/proc : (∀ [state]
-                                {state
-                                 -> {state -> (IO state)} -> Double
-                                 -> {state -> hackett:Pict}
-                                 -> {hackett:KeyEvent -> state -> (IO state)}
-                                 -> {hackett:KeyEvent -> state -> (IO state)}
-                                 -> {Integer -> Integer -> hackett:MouseEvent -> state -> (IO state)}
-                                 -> (IO state)})]))
+            [random-integer : {Integer -> Integer -> (t:IO Integer)}]
+            [random-double : (t:IO Double)]
+            [animate : {{Integer -> hackett:t:Pict} -> (t:IO t:Unit)}]
+            [big-bang/proc
+             : (∀ [state]
+                  {state
+                   -> {state -> (t:IO state)} -> Double
+                   -> {state -> hackett:t:Pict}
+                   -> {hackett:t:KeyEvent -> state -> (t:IO state)}
+                   -> {hackett:t:KeyEvent -> state -> (t:IO state)}
+                   -> {Integer -> Integer -> hackett:t:MouseEvent -> state -> (t:IO state)}
+                   -> (t:IO state)})]))
 
   (define (pict->image p) (pict->bitmap- (force- p)))
 
@@ -72,15 +75,15 @@
       [_ (hackett:me:unknown str)]))
 
   (define ((random-integer low) high)
-    (io (λ- (rw) ((hackett:tuple rw) (random- (force- low) (force- high))))))
+    (IO (λ- (rw) ((hackett:Tuple rw) (random- (force- low) (force- high))))))
 
   (define random-double
-    (io (λ- (rw) ((hackett:tuple rw) (real->double-flonum- (random-))))))
+    (IO (λ- (rw) ((hackett:Tuple rw) (real->double-flonum- (random-))))))
 
   (define (animate f)
-    (io (λ- (rw)
+    (IO (λ- (rw)
           (animate- (λ- (x) (pict->image ((force- f) x))))
-          ((hackett:tuple rw) hackett:unit))))
+          ((hackett:Tuple rw) hackett:Unit))))
 
   (define (((((((big-bang/proc init-state)
                 tick-fn) tick-rate)
@@ -88,8 +91,8 @@
              key-fn)
             release-fn)
            mouse-fn)
-    (io (λ- (rw)
-          ((hackett:tuple rw)
+    (IO (λ- (rw)
+          ((hackett:Tuple rw)
            (big-bang- init-state
              [on-tick- (λ- (s) (force- (unsafe-run-io! ((force- tick-fn) s))))
                        (force- tick-rate)]

--- a/hackett-demo/hackett/demo/web-server.rkt
+++ b/hackett-demo/hackett/demo/web-server.rkt
@@ -11,6 +11,7 @@
 ; These datatypes are needed by both the untyped bindings and the typed code, so we need to put them
 ; in a a common submodule that can be imported by both.
 (module shared hackett
+  (#%require/only-types hackett)
   (provide (data Request) (data Response) response-status response-body)
   (data Request (request String))
   (data Response (response Integer String))
@@ -23,8 +24,10 @@
 ; passes a request to a callback function for every request. The callback should produce a response,
 ; which contains a response body and a status code.
 (module untyped racket/base
-  (require (prefix-in hackett: (combine-in hackett (submod ".." shared)))
-           (only-in hackett : -> Integer String IO Unit)
+  (require (only-in hackett/private/base unmangle-types-in)
+           (prefix-in hackett: (unmangle-types-in #:no-introduce
+                                                  (combine-in hackett (submod ".." shared))))
+           (only-in (unmangle-types-in #:no-introduce hackett) : -> Integer String IO Unit)
            hackett/private/prim/type-provide
            (only-in hackett/private/prim/type io)
            racket/string

--- a/hackett-demo/hackett/demo/web-server.rkt
+++ b/hackett-demo/hackett/demo/web-server.rkt
@@ -24,7 +24,7 @@
 ; passes a request to a callback function for every request. The callback should produce a response,
 ; which contains a response body and a status code.
 (module untyped racket/base
-  (require (only-in hackett/private/base unmangle-types-in)
+  (require hackett/private/type-reqprov
            (prefix-in hackett: (unmangle-types-in #:prefix t:
                                                   (combine-in hackett (submod ".." shared))))
            (only-in (unmangle-types-in #:prefix t: hackett)

--- a/hackett-demo/hackett/demo/web-server.rkt
+++ b/hackett-demo/hackett/demo/web-server.rkt
@@ -13,11 +13,11 @@
 (module shared hackett
   (#%require/only-types hackett)
   (provide (data Request) (data Response) response-status response-body)
-  (data Request (request String))
-  (data Response (response Integer String))
+  (data Request (Request String))
+  (data Response (Response Integer String))
 
-  (def response-status (λ [(response status _)] status))
-  (def response-body (λ [(response _ body)] body)))
+  (def response-status (λ [(Response status _)] status))
+  (def response-body (λ [(Response _ body)] body)))
 
 ; This module implements some very simple bindings to the Racket web server than can be called from
 ; typed code. It provides a single binding, run-server, which just binds the web server to a port and
@@ -25,11 +25,12 @@
 ; which contains a response body and a status code.
 (module untyped racket/base
   (require (only-in hackett/private/base unmangle-types-in)
-           (prefix-in hackett: (unmangle-types-in #:no-introduce
+           (prefix-in hackett: (unmangle-types-in #:prefix t:
                                                   (combine-in hackett (submod ".." shared))))
-           (only-in (unmangle-types-in #:no-introduce hackett) : -> Integer String IO Unit)
+           (only-in (unmangle-types-in #:prefix t: hackett)
+                    : t:IO t:Unit [t:-> ->] [t:Integer Integer] [t:String String])
            hackett/private/prim/type-provide
-           (only-in hackett/private/prim/type io)
+           (only-in hackett/private/prim/type IO)
            racket/string
            racket/promise
            net/url-structs
@@ -37,13 +38,14 @@
            web-server/http/response-structs
            web-server/servlet-env)
 
-  (provide (typed-out [run-server : {Integer -> {hackett:Request -> hackett:Response} -> (IO Unit)}]))
+  (provide (typed-out
+            [run-server : {Integer -> {hackett:t:Request -> hackett:t:Response} -> (t:IO t:Unit)}]))
 
   (define (req->Request req)
-    (hackett:request (string-join (map path/param-path (url-path (request-uri req))) "/")))
+    (hackett:Request (string-join (map path/param-path (url-path (request-uri req))) "/")))
 
   (define ((run-server port) handler)
-    (io (λ (rw)
+    (IO (λ (rw)
           (serve/servlet
            #:port port
            #:launch-browser? #f
@@ -55,7 +57,7 @@
                 #:code (force (hackett:response-status res))
                 #:mime-type #"text/plain; charset=utf-8"
                 (λ (out) (displayln (force (hackett:response-body res)) out))))))
-          ((hackett:tuple rw) hackett:unit)))))
+          ((hackett:Tuple rw) hackett:Unit)))))
 
 ;; ---------------------------------------------------------------------------------------------------
 
@@ -65,8 +67,8 @@
 (provide (class Param->) (class ->Body) defserver)
 
 (defn request->path-segments : {Request -> (List String)}
-  [[(request "")] {"" :: nil}]
-  [[(request path)] (string-split "/" path)])
+  [[(Request "")] {"" :: Nil}]
+  [[(Request path)] (string-split "/" path)])
 
 (class (Param-> a)
   [param-> : {String -> a}])
@@ -111,7 +113,7 @@
                                      #'handler-annotated
                                      #'(handler-annotated (param-> segment.var) ... ...))
              #:attr case-clause (template [{{?@ segment.pat ::} ... nil}
-                                           (response 200 (->body handler-expr))])]))
+                                           (Response 200 (->body handler-expr))])]))
 
 (define-syntax-parser defserver
   #:literals [-> =>]

--- a/hackett-doc/scribble/manual/hackett/private/manual-bind.rkt
+++ b/hackett-doc/scribble/manual/hackett/private/manual-bind.rkt
@@ -1,0 +1,272 @@
+; The contents of this module include a partial copy of the implementation of ‘defform’ from
+; scribble/private/manual-bind, tweaked to support rendering different symbolic names in place of the
+; actual names of documented bindings. This is necessary to allow Hackett to properly document types,
+; which are prefixed with ‘#%hackett-type:’, a mangling scheme that should not appear in the
+; documentation.
+;
+; The contents of this module are dual-licensed under the compatible ISC and MIT licenses, the former
+; being the license of the entire Hackett project, the latter the license of the Racket distribution.
+; The full text of the original license is reproduced below:
+;
+; Copyright 2017 PLT Design
+;
+; Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+; associated documentation files (the "Software"), to deal in the Software without restriction,
+; including without limitation the rights to use, copy, modify, merge, publish, distribute,
+; sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+; furnished to do so, subject to the following conditions:
+;
+; The above copyright notice and this permission notice shall be included in all copies or substantial
+; portions of the Software.
+;
+; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+; NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+; OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#lang racket/base
+
+(require scribble/struct
+         scribble/racket
+         scribble/basic
+         scribble/manual-struct
+         scribble/private/qsloc
+         scribble/private/manual-utils
+         scribble/private/manual-vars
+         scribble/private/manual-scheme
+         scribble/private/manual-bind
+         racket/list
+         (for-syntax racket/base
+                     racket/syntax
+                     syntax/parse
+                     syntax/parse/experimental/template)
+         (for-label racket/base))
+
+(provide defform defform* defidform
+         (for-syntax kind-kw id-kw display-id-kw link-target?-kw
+                     literals-kw contracts-kw grammar subs-kw))
+
+(begin-for-syntax
+ (define-splicing-syntax-class kind-kw
+   #:description "#:kind keyword"
+   (pattern (~seq #:kind kind))
+   (pattern (~seq)
+            #:with kind #'#f))
+
+ (define-splicing-syntax-class id-kw
+   #:description "#:id keyword"
+   (pattern {~optional {~seq #:id defined-id:id}}))
+
+ (define-splicing-syntax-class display-id-kw
+   #:description "#:display-id keyword"
+   (pattern {~optional {~seq #:display-id display-id:id}}))
+
+ (define-splicing-syntax-class link-target?-kw
+   #:description "#:link-target? keyword"
+   (pattern (~seq #:link-target? expr))
+   (pattern (~seq)
+            #:with expr #'#t))
+
+ (define-splicing-syntax-class literals-kw
+   #:description "#:literals keyword"
+   (pattern (~seq #:literals (lit:id ...)))
+   (pattern (~seq)
+            #:with (lit ...) #'()))
+
+ (define-splicing-syntax-class contracts-kw
+   #:description "#:contracts keyword"
+   (pattern (~seq #:contracts (~and cs ([contract-nonterm:id contract-expr] ...))))
+   (pattern (~seq)
+            #:with (~and cs ((contract-nonterm contract-expr) ...)) #'()))
+
+ (define-syntax-class grammar
+   #:description "grammar"
+   (pattern ([non-term-id:id non-term-form ...+] ...)))
+
+ (define-splicing-syntax-class subs-kw
+   #:description "#:grammar keyword"
+   #:attributes (g (g.non-term-id 1) (g.non-term-form 2))
+   (pattern (~seq #:grammar g:grammar))
+   (pattern (~seq) #:with g:grammar #'())))
+
+(define-syntax (defform*/subs stx)
+  (syntax-parse stx
+    [(_ k:kind-kw lt:link-target?-kw d:id-kw d*:display-id-kw l:literals-kw [spec spec1 ...]
+        g:grammar
+        c:contracts-kw
+        desc ...)
+     (with-syntax* ([defined-id (if (attribute d.defined-id)
+                                    #'d.defined-id
+                                    (syntax-case #'spec ()
+                                      [(spec-id . _) #'spec-id]))]
+                    [display-id (if (attribute d*.display-id)
+                                    #'d*.display-id
+                                    (syntax-case #'spec ()
+                                      [(spec-id . _) #'spec-id]))]
+                    [(new-spec ...)
+                     (for/list ([spec (in-list (syntax->list #'(spec spec1 ...)))])
+                       (let loop ([spec spec])
+                         (if (and (identifier? spec)
+                                  (free-identifier=? spec #'display-id))
+                             (datum->syntax #'here '(unsyntax x) spec spec)
+                             (syntax-case spec ()
+                               [(a . b)
+                                (datum->syntax spec
+                                               (cons (loop #'a) (loop #'b))
+                                               spec
+                                               spec)]
+                               [_ spec]))))])
+       #'(with-togetherable-racket-variables
+            (l.lit ...)
+            ([form [display-id spec]] [form [display-id spec1]] ...
+             [non-term (g.non-term-id g.non-term-form ...)] ...)
+            (*defforms k.kind lt.expr (quote-syntax defined-id) (quote-syntax display-id)
+                       '(spec spec1 ...)
+                       (list (lambda (x) (racketblock0/form new-spec)) ...)
+                       '((g.non-term-id g.non-term-form ...) ...)
+                       (list (list (lambda () (racket g.non-term-id))
+                                   (lambda () (racketblock0/form g.non-term-form))
+                                   ...)
+                             ...)
+                       (list (list (lambda () (racket c.contract-nonterm))
+                                   (lambda () (racketblock0 c.contract-expr)))
+                             ...)
+                       (lambda () (list desc ...)))))]))
+
+(define-syntax (defform* stx)
+  (syntax-parse stx
+    [(_ k:kind-kw lt:link-target?-kw d:id-kw d*:display-id-kw l:literals-kw [spec ...]
+        subs:subs-kw c:contracts-kw desc ...)
+     (template/loc stx
+       (defform*/subs #:kind k.kind 
+         #:link-target? lt.expr
+         {?? {?@ . d}} {?? {?@ . d*}}
+         #:literals (l.lit ...)
+         [spec ...] subs.g #:contracts c.cs desc ...))]))
+
+(define-syntax (defform stx)
+  (syntax-parse stx
+    [(_ k:kind-kw lt:link-target?-kw d:id-kw d*:display-id-kw l:literals-kw spec
+        subs:subs-kw c:contracts-kw desc ...)
+     (template/loc stx
+       (defform*/subs #:kind k.kind
+         #:link-target? lt.expr
+         {?? {?@ . d}} {?? {?@ . d*}}
+         #:literals (l.lit ...)
+         [spec] subs.g #:contracts c.cs desc ...))]))
+
+(define-syntax (defidform stx)
+  (syntax-parse stx
+    [(_ k:kind-kw lt:link-target?-kw d:id-kw spec-id desc ...)
+     (template
+      (with-togetherable-racket-variables
+        ()
+        ()
+        (*defforms k.kind lt.expr
+                   (quote-syntax/loc {?? d.defined-id spec-id}) (quote-syntax/loc spec-id)
+                   '(spec-id)
+                   (list (lambda (x) (make-omitable-paragraph (list x))))
+                   null
+                   null
+                   null
+                   (lambda () (list desc ...)))))]))
+
+(define (defform-site defined-id display-id)
+  (let ([target-maker (id-to-form-target-maker defined-id #t)]
+        [content (to-element display-id #:defn? #t)]
+        [ref-content (to-element display-id)])
+    (target-maker
+     content
+     (lambda (tag)
+       (make-toc-target2-element
+        #f
+        (if display-id
+            (make-index-element
+             #f content tag
+             (list (datum-intern-literal (symbol->string (syntax-e display-id))))
+             (list ref-content)
+             (with-exporting-libraries
+                 (lambda (libs)
+                   (make-form-index-desc (syntax-e display-id)
+                                         libs))))
+            content)
+        tag
+        ref-content)))))
+
+(define (*defforms kind link? defined-id display-id forms form-procs subs sub-procs contract-procs
+                   content-thunk)
+  (parameterize ([current-meta-list '(... ...+)])
+    (make-box-splice
+     (cons
+      (make-blockquote
+       vertical-inset-style
+       (list
+        (make-table
+         boxed-style
+         (append
+          (for/list ([form (in-list forms)]
+                     [form-proc (in-list form-procs)]
+                     [i (in-naturals)])
+            (list
+             ((if (zero? i) (add-background-label (or kind "syntax")) values)
+              (list
+               ((or form-proc
+                    (lambda (x)
+                      (make-omitable-paragraph
+                       (list (to-element `(,x . ,(cdr form)))))))
+                (and display-id
+                     (if (and (eq? form (car forms))
+                              defined-id
+                              link?)
+                         (defform-site defined-id display-id)
+                         (to-element #:defn? #t display-id))))))))
+          (if (null? sub-procs)
+              null
+              (list (list flow-empty-line)
+                    (list (make-flow
+                           (list (let ([l (map (lambda (sub)
+                                                 (map (lambda (f) (f)) sub))
+                                               sub-procs)])
+                                   (*racketrawgrammars "specgrammar"
+                                                       (map car l)
+                                                       (map cdr l))))))))
+          (make-contracts-table contract-procs)))))
+      (content-thunk)))))
+
+(define (*racketrawgrammars style nonterms clauseses)
+  (make-table
+   `((valignment baseline baseline baseline baseline baseline)
+     (alignment right left center left left)
+     (style ,style))
+   (cdr
+    (append-map
+     (lambda (nonterm clauses)
+       (list*
+        (list flow-empty-line flow-empty-line flow-empty-line
+              flow-empty-line flow-empty-line)
+        (list (to-flow nonterm) flow-empty-line (to-flow "=") flow-empty-line
+              (make-flow (list (car clauses))))
+        (map (lambda (clause)
+               (list flow-empty-line flow-empty-line
+                     (to-flow "|") flow-empty-line
+                     (make-flow (list clause))))
+             (cdr clauses))))
+     nonterms clauseses))))
+
+(define (make-contracts-table contract-procs)
+  (if (null? contract-procs)
+      null
+      (append
+       (list (list flow-empty-line))
+       (list (list (make-flow
+                    (map (lambda (c)
+                           (make-table
+                            "argcontract"
+                            (list
+                             (list (to-flow (hspace 2))
+                                   (to-flow ((car c)))
+                                   flow-spacer
+                                   (to-flow ":")
+                                   flow-spacer
+                                   (make-flow (list ((cadr c))))))))
+                         contract-procs)))))))

--- a/hackett-doc/scribblings/hackett/guide.scrbl
+++ b/hackett-doc/scribblings/hackett/guide.scrbl
@@ -43,18 +43,18 @@ Once you have a REPL started, you can try evaluating some simple expressions:
 
 @(hackett-interaction
   3
-  true)
+  True)
 
 Note that the result is printed out, such as @racketresultfont{3}, but so is the type, such as
-@racket[Integer]. In Hackett, all valid expressions have a type, and the type can usually be inferred
-by the typechecker.
+@racket[t:Integer]. In Hackett, all valid expressions have a type, and the type can usually be
+inferred by the typechecker.
 
 The above expressions were very simple, just simple constants, so they are immediately returned
 without any additional evaluation. Calling some functions is slightly more interesting:
 
 @(hackett-interaction
   (eval:check (+ 1 2) 3)
-  (eval:check (not true) false))
+  (eval:check (not True) False))
 
 In Hackett, like any other Lisp, function calls are syntactically represented by surrounding
 subexpressions with parentheses. In any expression @racket[(_f _x _y _z)], @racket[_f] is a function
@@ -75,21 +75,21 @@ However, we can ask Hackett to only print the type of an expression by wrapping 
 @(hackett-interaction
   (#:type not))
 
-The type of @racket[not] is a @tech{function type}, which is represented by @racket[->]. The type can
-be read as “a function that takes a @racket[Bool] and produces (or returns) a @racket[Bool]”. If you
-attempt to apply something that is not a function, like @racket[3], the typechecker will reject the
-expression as ill-typed:
+The type of @racket[not] is a @tech{function type}, which is represented by @racket[t:->]. The type
+can be read as “a function that takes a @racket[t:Bool] and produces (or returns) a @racket[t:Bool]”.
+If you attempt to apply something that is not a function, like @racket[3], the typechecker will reject
+the expression as ill-typed:
 
 @(hackett-interaction
   #:no-preserve-source-locations
-  (eval:error (3 true)))
+  (eval:error (3 True)))
 
 The type of @racket[+] is slightly more complicated:
 
 @(hackett-interaction
   (#:type +))
 
-This type has two @racket[->] constructors in it, and it actually represents a function that
+This type has two @racket[t:->] constructors in it, and it actually represents a function that
 @emph{returns} another function. This is because all functions in Hackett are @deftech{curried}—that
 is, all functions actually only take a single argument, and multi-argument functions are simulated by
 writing functions that return other functions.
@@ -161,7 +161,7 @@ serve as extremely useful documentation to people reading the code.
 It’s possible to add a type signature to any definition by placing a type annotation after its name:
 
 @(hackett-interaction
-  (defn square : (-> Integer Integer)
+  (defn square : (t:-> t:Integer t:Integer)
     [[x] (* x x)])
   (eval:check (square 5) 25))
 
@@ -171,7 +171,7 @@ expected type, the typechecker will raise an error at compile time:
 
 @(hackett-interaction
   #:no-preserve-source-locations
-  (eval:error (def x : Integer "not an integer")))
+  (eval:error (def x : t:Integer "not an integer")))
 
 @section[#:tag "guide-hackett-essentials"]{Hackett Essentials}
 
@@ -190,8 +190,9 @@ itself:
   "Hello, world!")
 
 Generally, a single type describes many values, sometimes infinitely many! Hackett can represent any
-integer that will fit in memory, and all of them have the @racket[Integer] type. Similarly, there are
-infinitely many possible arrangements of characters, and all of them have the @racket[String] type.
+integer that will fit in memory, and all of them have the @racket[t:Integer] type. Similarly, there
+are infinitely many possible arrangements of characters, and all of them have the @racket[t:String]
+type.
 
 In Hackett, types are @emph{exclusively} a compile-time concept; they never persist at runtime. After
 a program has passed the typechecker, type information is thrown away; this process is known as
@@ -206,8 +207,8 @@ following syntax:
 @specform[(_function-expr arg-expr)]{
 
 @(hackett-examples
-  (not true)
-  (not (not true))
+  (not True)
+  (not (not True))
   ((+ 1) 2))}
 
 The above syntax @italic{applies} @racket[_function-expr] to @racket[_arg-expr], evaluating to the
@@ -229,23 +230,23 @@ the programmer is expected to specify a type rather than a value. The syntax of 
 the syntax of values, but be careful to never confuse the two: remember that types are evaluated at
 compile-time, and they will never mix with runtime values, they simply describe them.
 
-The simplest types are just names. For example, @racket[Integer], @racket[Bool], and @racket[String]
-are all types. These can be successfully used anywhere a type is expected:
+The simplest types are just names. For example, @racket[t:Integer], @racket[t:Bool], and
+@racket[t:String] are all types. These can be successfully used anywhere a type is expected:
 
 @(hackett-interaction
-  (: 42 Integer)
-  (: false Bool))
+  (: 42 t:Integer)
+  (: False t:Bool))
 
 Some types, however, are more complex. For example, consider the type of a @tech{list}. It would be
 silly to have many different types for all the different sorts of list one might need—that would
 require completely separate types for things like @racket[Integer-List], @racket[Bool-List], and
-@racket[String-List]. Instead, there is only a single @racket[List] type, but @racket[List] is not
-actually a type on its own. Rather, @racket[List] is combined with another type to produce a new type,
-such as @racket[(List Integer)] or @racket[(List String)].
+@racket[String-List]. Instead, there is only a single @racket[t:List] type, but @racket[t:List] is not
+actually a type on its own. Rather, @racket[t:List] is combined with another type to produce a new
+type, such as @racket[(t:List t:Integer)] or @racket[(t:List t:String)].
 
-This means that @racket[List] isn’t really a type, since types describe values, and @racket[List] is
-not a valid type on its own. Instead, @racket[List] is known as a @deftech{type constructor}, which
-can be applied to other types to produce a type.
+This means that @racket[t:List] isn’t really a type, since types describe values, and @racket[t:List]
+is not a valid type on its own. Instead, @racket[t:List] is known as a @deftech{type constructor},
+which can be applied to other types to produce a type.
 
 @subsection[#:tag "guide-infix-syntax"]{Infix Syntax}
 
@@ -328,7 +329,7 @@ to decide on a case-by-case basis. Some operators should be grouped the first wa
 
 @(hackett-interaction
   (eval:check {10 - 15 - 6} -11)
-  {1 :: 2 :: 3 :: nil})
+  {1 :: 2 :: 3 :: Nil})
 
 Operator fixity can be specified when a binding is defined by providing a @deftech{fixity annotation},
 which is either @racket[#:fixity left] or @racket[#:fixity right]. Using a fixity annotation, it is
@@ -341,10 +342,11 @@ possible to write a version of @racket[-] that associates right:
 If no fixity annotation is specified, the default fixity is @racket[left].
 
 Additionally, infix syntax can be used in types as well as expressions, and it works the same way.
-Type constructors may also have @tech{operator fixity}, most notably @racket[->], which associates
+Type constructors may also have @tech{operator fixity}, most notably @racket[t:->], which associates
 right. This makes writing type signatures for curried functions much more palatable, since
-@racket[{_a -> _b -> _c}] tends to be easier to visually scan than @racket[(-> _a (-> _b _c))],
-especially when the argument types are long or function types are nested in argument positions.
+@racket[{_a t:-> _b t:-> _c}] tends to be easier to visually scan than
+@racket[(t:-> _a (t:-> _b _c))], especially when the argument types are long or function types are
+nested in argument positions.
 
 @section[#:tag "guide-working-with-data"]{Working with data}
 
@@ -405,14 +407,14 @@ the different values of an enumeration. Here’s one way to write our @racket[is
 
 @(hackett-interaction
   #:eval enumerations-eval
-  (defn is-weekend? : {Weekday -> Bool}
-    [[sunday] true]
-    [[monday] false]
-    [[tuesday] false]
-    [[wednesday] false]
-    [[thursday] false]
-    [[friday] false]
-    [[saturday] true])
+  (defn is-weekend? : {Weekday t:-> t:Bool}
+    [[sunday] True]
+    [[monday] False]
+    [[tuesday] False]
+    [[wednesday] False]
+    [[thursday] False]
+    [[friday] False]
+    [[saturday] True])
   (is-weekend? saturday)
   (is-weekend? wednesday))
 
@@ -425,10 +427,10 @@ sort of “fallthrough” case:
 
 @(hackett-interaction
   #:eval enumerations-eval
-  (defn is-weekend? : {Weekday -> Bool}
-    [[sunday] true]
-    [[saturday] true]
-    [[_] false])
+  (defn is-weekend? : {Weekday t:-> t:Bool}
+    [[sunday] True]
+    [[saturday] True]
+    [[_] False])
   (is-weekend? saturday)
   (is-weekend? wednesday))
 
@@ -443,53 +445,53 @@ multiple values of the same type. One such data structure is a @tech{list}, whic
 singly-linked list. Lists are @emph{homogenous}, which means they hold a set of values that all have
 the same @tech{type}.
 
-A list is built out of two fundamental pieces: the empty list, named @racket[nil], and the “cons”
+A list is built out of two fundamental pieces: the empty list, named @racket[Nil], and the “cons”
 constructor, named @racket[::]. These have the following types:
 
 @margin-note{
-  The use of @racket[forall] in the types of @racket[nil] and @racket[::] indicates that lists are
+  The use of @racket[t:forall] in the types of @racket[Nil] and @racket[::] indicates that lists are
   @emph{polymorphic}—that is, they can hold values of any type. This will be covered in more detail
   in a future section.}
 
 @nested[#:style 'inset]{
   @deftogether[
-    [@defthing[#:link-target? #f nil (forall [a] (List a))]
-     @defthing[#:link-target? #f :: (forall [a] {a -> (List a) -> (List a)})]]]}
+    [@defthing[#:link-target? #f Nil (t:forall [a] (t:List a))]
+     @defthing[#:link-target? #f :: (t:forall [a] {a t:-> (t:List a) t:-> (t:List a)})]]]}
 
 Essentially, @racket[::] prepends a single element to an existing list (known as the “tail” of the
-list), and @racket[nil] is the end of every list. To create a single-element list, use @racket[::]
+list), and @racket[Nil] is the end of every list. To create a single-element list, use @racket[::]
 to prepend an element to the empty list:
 
 @(hackett-interaction
-  {1 :: nil})
+  {1 :: Nil})
 
 A list of more elements can be created with nested uses of @racket[::]:
 
 @(hackett-interaction
-  {1 :: {2 :: {3 :: nil}}})
+  {1 :: {2 :: {3 :: Nil}}})
 
 Additionally, @racket[::] is an @tech{infix operator} that associates right, so nested braces can be
 elided when constructing lists:
 
 @(hackett-interaction
-  {1 :: 2 :: 3 :: nil})
+  {1 :: 2 :: 3 :: Nil})
 
 Once we have a list, we can do various things with it. For example, we can concatenate two lists
 together using the @racket[++] operator:
 
 @(hackett-interaction
-  {{1 :: 2 :: nil} ++ {3 :: 4 :: nil}})
+  {{1 :: 2 :: Nil} ++ {3 :: 4 :: Nil}})
 
 We can sum a list of numbers using the @racket[sum] function:
 
 @(hackett-interaction
-  (eval:check (sum {1 :: 2 :: 3 :: nil}) 6))
+  (eval:check (sum {1 :: 2 :: 3 :: Nil}) 6))
 
 We can even apply a function to each element of a list to produce a new list by using the @racket[map]
 function:
 
 @(hackett-interaction
-  (map (+ 1) {1 :: 2 :: 3 :: nil}))
+  (map (+ 1) {1 :: 2 :: 3 :: Nil}))
 
 Combining this with our @racket[Weekday] type from earlier, we can create a list of all the days in
 the week:
@@ -498,7 +500,7 @@ the week:
   #:eval enumerations-eval
   (def weekdays : (List Weekday)
     {sunday :: monday :: tuesday :: wednesday
-     :: thursday :: friday :: saturday :: nil}))
+     :: thursday :: friday :: saturday :: Nil}))
 
 Using @racket[filter] combined with the @racket[is-weekend?] function we wrote earlier, it’s possible
 to produce a list that contains only weekends:
@@ -513,10 +515,10 @@ to produce a list that contains only weekends:
 
 In Hackett, functions are generally expected to be @deftech[#:key "total function"]{total}, which
 means they should produce a result for all possible inputs. For example, @racket[not] is obviously
-defined for both @racket[true] and @racket[false], which are the only possible values of the
-@racket[Bool] type. Total functions allow a programmer to reason about programs using the types alone;
-a function with the type @racket[{A -> B}] implies that is is always possible to get a @racket[B] when
-you have an @racket[A].
+defined for both @racket[True] and @racket[False], which are the only possible values of the
+@racket[t:Bool] type. Total functions allow a programmer to reason about programs using the types
+alone; a function with the type @racket[{A t:-> B}] implies that is is always possible to get a
+@racket[B] when you have an @racket[A].
 
 @see-reference-note["reference-controlling-evaluation"]{partial functions}
 
@@ -540,7 +542,7 @@ anything, but this is only possible because it will never actually return anythi
 
 @(hackett-interaction
   #:no-preserve-source-locations
-  (eval:error (: (error! "urk!") Unit)))
+  (eval:error (: (error! "urk!") t:Unit)))
 
 Partial functions in Hackett are idiomatically indicated by including a @litchar{!} symbol at the end
 of their names, but this is only a convention; it is not enforced by the compiler or typechecker.
@@ -549,7 +551,7 @@ The @racket[error!] function can be considered a way to subvert the type system.
 is to provide a programmer the ability to mark cases which are “impossible” based on the logic of the
 program, but the typechecker cannot determine that is true. Of course, in practice, things that where
 once truly impossible may eventually become possible as code changes, so using some other notion of
-failure (such as returning a value wrapped in @racket[Maybe]) is generally preferred whenever
+failure (such as returning a value wrapped in @racket[t:Maybe]) is generally preferred whenever
 possible.
 
 In addition to @racket[error!], another partial value provided by Hackett is @racket[undefined!]. This
@@ -566,7 +568,7 @@ never return, but there is another possibility besides halting: the function can
 loop. Here is an example of such a function, called @racket[diverge!]:
 
 @(racketblock
-  (defn diverge! : (forall [a] {String -> a})
+  (defn diverge! : (t:forall [a] {t:String t:-> a})
     [[x] (diverge! x)]))
 
 This sort of function is often @emph{also} considered partial, since it does not return a value for
@@ -577,7 +579,7 @@ that! This can result in curious behavior, where a partial function does not cau
 or diverge, simply because it isn’t evaluated:
 
 @(hackett-interaction
-  (const unit (error! "never gets here")))
+  (const Unit (error! "never gets here")))
 
 In fact, a partial function can “lurk” in an unevaluated thunk for quite a long time, but forcing its
 evaluation will cause its effects to become visible. These unpredictable effects are another reason to

--- a/hackett-doc/scribblings/hackett/private/util.rkt
+++ b/hackett-doc/scribblings/hackett/private/util.rkt
@@ -35,11 +35,14 @@
 ;; evaluation
 
 (define (make-hackett-eval)
-  (make-base-eval #:lang 'hackett '(require hackett/data/identity
-                                            hackett/monad/error
-                                            hackett/monad/reader
-                                            hackett/monad/trans
-                                            (only-in hackett/private/prim unsafe-run-io!))))
+  (let ([hackett-eval (make-base-eval #:lang 'hackett)])
+    (hackett-eval '(require hackett
+                            hackett/data/identity
+                            hackett/monad/error
+                            hackett/monad/reader
+                            hackett/monad/trans
+                            (only-in hackett/private/prim unsafe-run-io!)))
+    hackett-eval))
 
 (define-simple-macro (hackett-examples
                       {~or {~optional {~seq #:eval eval:expr}}

--- a/hackett-doc/scribblings/hackett/reference.scrbl
+++ b/hackett-doc/scribblings/hackett/reference.scrbl
@@ -495,25 +495,25 @@ argument. Notably, the second argument will not be evaluated at all if the first
 
 @defmodule[hackett/data/identity]
 
-@defdata[(t:Identity a) (identity a)]{
+@defdata[(t:Identity a) (Identity a)]{
 
 A simple wrapper type with a variety of typeclass instances that defer to the value inside whenever
 possible. Most useful for its @racket[t:Functor], @racket[t:Applicate], and @racket[t:Monad] instances,
-which simply apply functions to the value inside the @racket[identity] wrapper, making it serve as
+which simply apply functions to the value inside the @racket[Identity] wrapper, making it serve as
 a “no-op” wrapper of sorts.
 
 @(hackett-interaction
-  (identity 5)
-  (map (+ 1) (identity 5))
-  {(identity (+ 1)) <*> (identity 5)}
-  {(identity "hello, ") ++ (identity "world")})}
+  (Identity 5)
+  (map (+ 1) (Identity 5))
+  {(Identity (+ 1)) <*> (Identity 5)}
+  {(Identity "hello, ") ++ (Identity "world")})}
 
 @defproc[(run-identity [x (t:Identity a)]) a]{
 
-Unwraps and returns the value inside an @racket[identity] wrapper.
+Unwraps and returns the value inside an @racket[Identity] wrapper.
 
 @(hackett-interaction
-  (run-identity (identity 5)))}
+  (run-identity (Identity 5)))}
 
 @subsection[#:tag "reference-tuples"]{Tuples}
 
@@ -1148,7 +1148,7 @@ Lifts a computation from the argument monad to the constructed monad.}}
 
 @defmodule[hackett/monad/reader]
 
-@defdata[(t:ReaderT r m a) (reader-t {r t:-> (m a)})]{
+@defdata[(t:ReaderT r m a) (ReaderT {r t:-> (m a)})]{
 
 The @deftech{reader monad transformer}, a @tech{monad transformer} that extends a monad with a
 read-only dynamic environment. The environment can be accessed with @racket[ask] and locally modified

--- a/hackett-doc/scribblings/hackett/reference.scrbl
+++ b/hackett-doc/scribblings/hackett/reference.scrbl
@@ -2,6 +2,12 @@
 
 @(require scribblings/hackett/private/util)
 
+@(module racket-labels racket/base
+   (require scribble/manual (for-label racket/base))
+   (provide racket-require)
+   (define racket-require @racket[require]))
+@(require 'racket-labels)
+
 @title[#:tag "reference" #:style 'toc]{The Hackett Reference}
 
 This section provides reference-style documentation for all of the bindings provided by @hash-lang[]
@@ -42,9 +48,9 @@ error is produced.
 
 @(hackett-examples
   #:no-preserve-source-locations
-  (: 42 Integer)
-  (: "hello" String)
-  (eval:error (: "hello" Integer)))
+  (: 42 t:Integer)
+  (: "hello" t:String)
+  (eval:error (: "hello" t:Integer)))
 
 Additionally, some forms (such as @racket[def] and @racket[defn]) recognize literal uses of @racket[:]
 to provide additional locations for type annotations.}
@@ -69,8 +75,8 @@ inferred from @racket[val-expr].
   #:no-preserve-source-locations
   (def x 7)
   (eval:check x 7)
-  (def y : Integer 7)
-  (eval:error (def z : String 7)))
+  (def y : t:Integer 7)
+  (eval:error (def z : t:String 7)))
 
 If @racket[fixity] is specified, it defines @racket[id]’s @tech{operator fixity} when used as an
 @tech{infix operator}.
@@ -101,7 +107,7 @@ following combination of @racket[def], @racket[lambda], and @racket[case*]:
 The @racket[defn] form is generally preferred when defining top-level functions.
 
 @(hackett-examples
-  (defn square : (-> Integer Integer)
+  (defn square : (t:-> t:Integer t:Integer)
     [[x] {x * x}])
   (eval:check (square 5) 25))}
 
@@ -131,9 +137,9 @@ combination of @racket[lambda] and @racket[case*]:
       [[arg-pat ...] body-expr] ...)))
 
 @(hackett-examples
-  (eval:check ((λ* [[(just x)] x]
-                   [[nothing] 0])
-               (just 42))
+  (eval:check ((λ* [[(Just x)] x]
+                   [[Nothing] 0])
+               (Just 42))
               42))}
 
 @subsection[#:tag "reference-local-binding"]{Local Bindings}
@@ -195,9 +201,9 @@ Matches @racket[val-expr] against each @racket[pat], in order. The result of the
 result of the @racket[body-expr] for the first matching @racket[pat].
 
 @(hackett-examples
-  (eval:check (case (just 42)
-                [(just x) x]
-                [nothing 0])
+  (eval:check (case (Just 42)
+                [(Just x) x]
+                [Nothing 0])
               42))}
 
 @defform[(case* [val-expr ...+]
@@ -207,12 +213,20 @@ Like @racket[case], but matches against multiple values at once. Each case only 
 @racket[pat]s succeed.
 
 @(hackett-examples
-  (eval:check (case* [(just 1) (just 2)]
-                [[(just _) nothing] "first"]
-                [[nothing (just _)] "second"]
-                [[(just _) (just _)] "both"]
-                [[nothing nothing] "neither"])
+  (eval:check (case* [(Just 1) (Just 2)]
+                [[(Just _) Nothing] "first"]
+                [[Nothing (Just _)] "second"]
+                [[(Just _) (Just _)] "both"]
+                [[Nothing Nothing] "neither"])
               "both"))}
+
+@subsection[#:tag "reference-imports-exports"]{Imports}
+
+@defform[(require require-spec ...)]{
+
+Imports bindings from a module, just like @racket-require from @racketmodname[racket/base]. The
+@racket[require] binding provided by @racketmodname[hackett] adds support for properly importing
+bindings in the type namespace, but otherwise, the behavior is the same.}
 
 @section[#:tag "reference-datatypes"]{Datatypes}
 
@@ -250,16 +264,16 @@ contains the provided values.
 @(hackett-examples
   #:eval data-examples-eval
   (data Foo
-    (foo1 Integer Bool)
-    (foo2 String)
+    (foo1 t:Integer t:Bool)
+    (foo2 t:String)
     foo3)
-  (instance (Show Foo)
+  (instance (t:Show Foo)
     [show (λ* [[(foo1 a b)] {"(foo1 " ++ (show a) ++ " "
                                       ++ (show b) ++ ")"}]
               [[(foo2 a)] {"(foo2 " ++ (show a) ++ ")"}]
               [[foo3] "foo3"])])
   (#:type foo1)
-  (foo1 42 true)
+  (foo1 42 True)
   (#:type foo2)
   (foo2 "hello")
   foo3)
@@ -271,7 +285,7 @@ pattern-matching allows extracting values stored “inside” data constructors.
 
 @(hackett-examples
   #:eval data-examples-eval
-  (case (foo1 42 true)
+  (case (foo1 42 True)
     [(foo1 n _) n]
     [(foo2 _)   2]
     [foo3       3]))
@@ -284,7 +298,7 @@ specified controls the fixity used by the associated @racket[type-constructor-id
   (data (Tree a)
     {(Tree a) :&: (Tree a)} #:fixity right
     (leaf a))
-  (instance (forall [a] (Show a) => (Show (Tree a)))
+  (instance (t:forall [a] (t:Show a) t:=> (t:Show (Tree a)))
     [show (λ* [[{a :&: b}] {"{" ++ (show a) ++ " :&: " ++ (show b) ++ "}"}]
               [[(leaf a)] {"(leaf " ++ (show a) ++ ")"}])])
   {(leaf 1) :&: (leaf 2) :&: (leaf 3)})}
@@ -292,7 +306,7 @@ specified controls the fixity used by the associated @racket[type-constructor-id
 
 @subsection[#:tag "reference-numbers"]{Numbers}
 
-@defidform[#:kind "type" Integer]{
+@deftype[t:Integer]{
 
 The type of arbitrary-precision integers. Just as with numbers in @hash-lang[] @racketmodname[racket],
 integers will be represented as @tech[#:doc '(lib "scribblings/reference/reference.scrbl")]{fixnums},
@@ -300,41 +314,41 @@ machine integers, where possible. Values that exceed this range will automatical
 arbitrary-precision “bignums”.}
 
 @deftogether[
- [@defthing[+ {Integer -> Integer -> Integer}]
-  @defthing[- {Integer -> Integer -> Integer}]
-  @defthing[* {Integer -> Integer -> Integer}]]]{
+ [@defthing[+ {t:Integer t:-> t:Integer t:-> t:Integer}]
+  @defthing[- {t:Integer t:-> t:Integer t:-> t:Integer}]
+  @defthing[* {t:Integer t:-> t:Integer t:-> t:Integer}]]]{
 
 These functions provide simple, arbitrary-precision, integral arithmetic.}
 
 @deftogether[
- [@defthing[> {Integer -> Integer -> Bool}]
-  @defthing[< {Integer -> Integer -> Bool}]
-  @defthing[>= {Integer -> Integer -> Bool}]
-  @defthing[<= {Integer -> Integer -> Bool}]]]{
+ [@defthing[> {t:Integer t:-> t:Integer t:-> t:Bool}]
+  @defthing[< {t:Integer t:-> t:Integer t:-> t:Bool}]
+  @defthing[>= {t:Integer t:-> t:Integer t:-> t:Bool}]
+  @defthing[<= {t:Integer t:-> t:Integer t:-> t:Bool}]]]{
 
 Comparison operators on integers.}
 
-@defidform[#:kind "type" Double]{
+@deftype[t:Double]{
 
 The type of double-precision IEEE 754 floating-point numbers, known as
 @tech[#:doc '(lib "scribblings/reference/reference.scrbl")]{flonums} in @hash-lang[]
 @racketmodname[racket].}
 
 @deftogether[
- [@defthing[d+ {Double -> Double -> Double}]
-  @defthing[d- {Double -> Double -> Double}]
-  @defthing[d* {Double -> Double -> Double}]
-  @defthing[d/ {Double -> Double -> Double}]]]{
+ [@defthing[d+ {t:Double t:-> t:Double t:-> t:Double}]
+  @defthing[d- {t:Double t:-> t:Double t:-> t:Double}]
+  @defthing[d* {t:Double t:-> t:Double t:-> t:Double}]
+  @defthing[d/ {t:Double t:-> t:Double t:-> t:Double}]]]{
 
-These functions provide simple, floating-point arithmentic on @racket[Double]s.}
+These functions provide simple, floating-point arithmentic on @racket[t:Double]s.}
 
 @subsection[#:tag "reference-strings"]{Strings}
 
-@defidform[#:kind "type" String]{
+@deftype[t:String]{
 
 The type of strings, which can be constructed using string literals.}
 
-@defthing[string-length {String -> Integer}]{
+@defthing[string-length {t:String t:-> t:Integer}]{
 
 Returns the length of a string, in characters.
 
@@ -342,7 +356,7 @@ Returns the length of a string, in characters.
   (eval:check (string-length "hello") 5)
   (eval:check (string-length "Λάμβδα") 6))}
 
-@defthing[string-split {String -> String -> (List String)}]{
+@defthing[string-split {t:String t:-> t:String t:-> (t:List t:String)}]{
 
 Splits a string on all instances of a separator string.
 
@@ -353,25 +367,25 @@ Splits a string on all instances of a separator string.
 
 @subsection[#:tag "reference-functions"]{Functions}
 
-@defform[#:kind "type constructor" (-> a b)]{
+@deftycon[(t:-> a b)]{
 
 A type constructor of arity 2 that represents functions, where @racket[a] is the type of value the
 function accepts as an argument, and @racket[b] is the type of the result. Functions of higher arities
 are represented via @tech[#:key "curried"]{currying}.}
 
-@defthing[id (forall [a] {a -> a})]{
+@defthing[id (t:forall [a] {a t:-> a})]{
 
 The identity function. Returns its argument unchanged.}
 
-@defthing[const (forall [a b] {a -> b -> a})]{
+@defthing[const (t:forall [a b] {a t:-> b t:-> a})]{
 
 Accepts two arguments and returns the first, ignoring the second.
 
 @(hackett-examples
   (eval:check (const "hello" "goodbye") "hello")
-  (eval:check (const unit (error! "never gets here")) unit))}
+  (eval:check (const Unit (error! "never gets here")) Unit))}
 
-@defthing[|.| (forall [a b c] {{b -> c} -> {a -> b} -> {a -> c}})]{
+@defthing[|.| (t:forall [a b c] {{b t:-> c} t:-> {a t:-> b} t:-> {a t:-> c}})]{
 
 Function composition. Given two functions @racket[_f] and @racket[_g], then @racket[({_f |.| _g} _x)]
 is equivalent to @racket[(_f (_g _x))].
@@ -380,111 +394,111 @@ is equivalent to @racket[(_f (_g _x))].
   (def add1AndDouble {(* 2) |.| (+ 1)})
   (eval:check (add1AndDouble 3) 8))}
 
-@defthing[$ (forall [a b] {{a -> b} -> a -> b})]{
+@defthing[$ (t:forall [a b] {{a t:-> b} t:-> a t:-> b})]{
 
 Function application as a binary operator. Not especially useful, since @racket[{_f $ _x}] is
 equivalent to @racket[(_f _x)], but sometimes convenient when used higher-order.}
 
-@defthing[& (forall [a b] {a -> {a -> b} -> b})]{
+@defthing[& (t:forall [a b] {a t:-> {a t:-> b} t:-> b})]{
 
 Reverse function application. This function is a flipped version of @racket[$] that accepts the
 argument first and the function second.}
 
-@defthing[flip (forall [a b c] {{a -> b -> c} -> b -> a -> c})]{
+@defthing[flip (t:forall [a b c] {{a t:-> b t:-> c} t:-> b t:-> a t:-> c})]{
 
 Produces a function with the same behavior as another function, but with its first two arguments
 flipped.
 
 @(hackett-examples
-  (flip :: nil 3))}
+  (flip :: Nil 3))}
 
 @subsection[#:tag "reference-quantification"]{Quantification and Constrained Types}
 
 @deftogether[
- [@defform*[#:literals [=>]
-            [(forall [var-id ...+] type)
-             (forall [var-id ...+] constraint ...+ => type)]]
-  @defform*[#:literals [=>]
-            [(∀ [var-id ...+] type)
-             (∀ [var-id ...+] constraint ...+ => type)]]]]{
+ [@deftycon*[#:literals [t:=>]
+             [(t:forall [var-id ...+] type)
+              (t:forall [var-id ...+] constraint ...+ t:=> type)]]
+  @deftycon*[#:literals [t:=>]
+             [(t:∀ [var-id ...+] type)
+              (t:∀ [var-id ...+] constraint ...+ t:=> type)]]]]{
 
 Universal quantification over types. Within @racket[type], each @racket[var-id] is bound to a fresh,
 universally quantified type.
 
-The second form is a shorthand that provides a nicer syntax for types constructed with @racket[=>]
-nested immediately within @racket[forall]: @racket[(forall [var-id ...] constraint ... => type)] is
-precisely equivalent to @racket[(forall [var-id ...] (=> [constraint ...] type))].}
+The second form is a shorthand that provides a nicer syntax for types constructed with @racket[t:=>]
+nested immediately within @racket[t:forall]: @racket[(t:forall [var-id ...] constraint ... t:=> type)]
+is precisely equivalent to @racket[(t:forall [var-id ...] (t:=> [constraint ...] type))].}
 
-@defform[(=> [constraint ...+] type)]{
+@deftycon[(t:=> [constraint ...+] type)]{
 
 Builds a type that includes typeclass constraints. The resulting type is equivalent to @racket[type],
 with the requirement that each @racket[constraint] must hold.}
 
 @subsection[#:tag "reference-unit"]{Unit}
 
-@defdata[Unit unit]{
+@defdata[t:Unit Unit]{
 
-The unit type. Values of type @racket[Unit] only have one possible value (ignoring @tech{bottom}),
-@racket[unit]. A value of type @racket[unit] carries no information, so it is similar to @void-const
+The unit type. Values of type @racket[t:Unit] only have one possible value (ignoring @tech{bottom}),
+@racket[Unit]. A value of type @racket[t:Unit] carries no information, so it is similar to @void-const
 in @hash-lang[] @racketmodname[racket] or the @tt{void} return “type” in many C-like languages.}
 
 @subsection[#:tag "reference-booleans"]{Booleans}
 
-@defdata[Bool true false]{
+@defdata[t:Bool True False]{
 
 The @deftech{boolean} type, representing two binary states.}
 
-@defthing[not {Bool -> Bool}]{
+@defthing[not {t:Bool t:-> t:Bool}]{
 
-Inverts the @tech{boolean} it is applied to; that is, produces @racket[false] when given @racket[true]
-and produces @racket[true] when given @racket[false].}
+Inverts the @tech{boolean} it is applied to; that is, produces @racket[False] when given @racket[True]
+and produces @racket[True] when given @racket[False].}
 
-@defthing[if (forall [a] {Bool -> a -> a -> a})]{
+@defthing[if (t:forall [a] {t:Bool t:-> a t:-> a t:-> a})]{
 
-Performs case analysis on a @tech{boolean} value. If the supplied boolean is @racket[true], returns
+Performs case analysis on a @tech{boolean} value. If the supplied boolean is @racket[True], returns
 its second argument; otherwise, returns its third argument.
 
 Since Hackett is lazy, @racket[if] is an ordinary function, not a macro or special form, and it can be
 used higher-order if desired.
 
 @(hackett-examples
-  (eval:check (if true "first" "second") "first")
-  (eval:check (if false "first" "second") "second"))}
+  (eval:check (if True "first" "second") "first")
+  (eval:check (if False "first" "second") "second"))}
 
-@defthing[\|\| {Bool -> Bool -> Bool}]{
+@defthing[\|\| {t:Bool t:-> t:Bool t:-> t:Bool}]{
 
-Returns @racket[true] if its first argument is @racket[true]; otherwise, returns its second argument.
-Notably, the second argument will not be evaluated at all if the first argument is @racket[true], but
+Returns @racket[True] if its first argument is @racket[True]; otherwise, returns its second argument.
+Notably, the second argument will not be evaluated at all if the first argument is @racket[True], but
 the first argument will always be forced when the result is forced.
 
 @(hackett-examples
-  (eval:check {true \|\| true} true)
-  (eval:check {false \|\| true} true)
-  (eval:check {true \|\| false} true)
-  (eval:check {false \|\| false} false)
-  (eval:check {true \|\| (error! "never gets here")} true))}
+  (eval:check {True \|\| True} True)
+  (eval:check {False \|\| True} True)
+  (eval:check {True \|\| False} True)
+  (eval:check {False \|\| False} False)
+  (eval:check {True \|\| (error! "never gets here")} True))}
 
-@defthing[&& {Bool -> Bool -> Bool}]{
+@defthing[&& {t:Bool t:-> t:Bool t:-> t:Bool}]{
 
-Returns @racket[false] if its first argument is @racket[false]; otherwise, returns its second
+Returns @racket[False] if its first argument is @racket[False]; otherwise, returns its second
 argument. Notably, the second argument will not be evaluated at all if the first argument is
-@racket[false], but the first argument will always be forced when the result is forced.
+@racket[False], but the first argument will always be forced when the result is forced.
 
 @(hackett-examples
-  (eval:check {true && true} true)
-  (eval:check {false && true} false)
-  (eval:check {true && false} false)
-  (eval:check {false && false} false)
-  (eval:check {false && (error! "never gets here")} false))}
+  (eval:check {True && True} True)
+  (eval:check {False && True} False)
+  (eval:check {True && False} False)
+  (eval:check {False && False} False)
+  (eval:check {False && (error! "never gets here")} False))}
 
 @subsection[#:tag "reference-identity"]{The Identity Type}
 
 @defmodule[hackett/data/identity]
 
-@defdata[(Identity a) (identity a)]{
+@defdata[(t:Identity a) (identity a)]{
 
 A simple wrapper type with a variety of typeclass instances that defer to the value inside whenever
-possible. Most useful for its @racket[Functor], @racket[Applicative], and @racket[Monad] instances,
+possible. Most useful for its @racket[t:Functor], @racket[t:Applicate], and @racket[t:Monad] instances,
 which simply apply functions to the value inside the @racket[identity] wrapper, making it serve as
 a “no-op” wrapper of sorts.
 
@@ -494,7 +508,7 @@ a “no-op” wrapper of sorts.
   {(identity (+ 1)) <*> (identity 5)}
   {(identity "hello, ") ++ (identity "world")})}
 
-@defproc[(run-identity [x (Identity a)]) a]{
+@defproc[(run-identity [x (t:Identity a)]) a]{
 
 Unwraps and returns the value inside an @racket[identity] wrapper.
 
@@ -503,188 +517,188 @@ Unwraps and returns the value inside an @racket[identity] wrapper.
 
 @subsection[#:tag "reference-tuples"]{Tuples}
 
-@defdata[(Tuple a b) (tuple a b)]{
+@defdata[(t:Tuple a b) (Tuple a b)]{
 
 The @deftech{tuple} type, which contains a pair of possibly heterogenous values.}
 
-@defthing[fst (forall [a b] {(Tuple a b) -> a})]{
+@defthing[fst (t:forall [a b] {(t:Tuple a b) t:-> a})]{
 
 Extracts the first element of a @tech{tuple}.
 
 @(hackett-examples
-  (eval:check (fst (tuple 42 "hello")) 42))}
+  (eval:check (fst (Tuple 42 "hello")) 42))}
 
-@defthing[snd (forall [a b] {(Tuple a b) -> b})]{
+@defthing[snd (t:forall [a b] {(t:Tuple a b) t:-> b})]{
 
 Extracts the second element of a @tech{tuple}.
 
 @(hackett-examples
-  (eval:check (snd (tuple 42 "hello")) "hello"))}
+  (eval:check (snd (Tuple 42 "hello")) "hello"))}
 
 @subsection[#:tag "reference-optionals"]{Optionals}
 
-@defdata[(Maybe a) (just a) nothing]{
+@defdata[(t:Maybe a) (Just a) Nothing]{
 
-A type that encodes the notion of an optional or nullable value. A value of type @racket[(Maybe a)]
+A type that encodes the notion of an optional or nullable value. A value of type @racket[(t:Maybe a)]
 implies that it @emph{might} contain a value of type @racket[a], but it also might contain nothing at
-all. This type is usually used to represent operations that can fail (where @racket[nothing]
+all. This type is usually used to represent operations that can fail (where @racket[Nothing]
 represents failure) or values that are not required to be present.
 
 @(hackett-examples
-  (map (+ 1) (just 5))
-  (map (+ 1) nothing))}
+  (map (+ 1) (Just 5))
+  (map (+ 1) Nothing))}
 
-@defproc[(maybe [v b] [f {a -> b}] [x (Maybe a)]) b]{
+@defproc[(maybe [v b] [f {a t:-> b}] [x (t:Maybe a)]) b]{
 
-The catamorphism for @racket[Maybe]. Produces @racket[v] when @racket[x] is @racket[nothing] and
-produces @racket[(f _y)] when @racket[x] is @racket[(just _y)].
+The catamorphism for @racket[t:Maybe]. Produces @racket[v] when @racket[x] is @racket[Nothing] and
+produces @racket[(f _y)] when @racket[x] is @racket[(Just _y)].
 
 @(hackett-examples
-  (eval:check (maybe 0 (+ 1) (just 5)) 6)
-  (eval:check (maybe 0 (+ 1) nothing) 0))}
+  (eval:check (maybe 0 (+ 1) (Just 5)) 6)
+  (eval:check (maybe 0 (+ 1) Nothing) 0))}
 
-@defproc[(from-maybe [v a] [x (Maybe a)]) a]{
+@defproc[(from-maybe [v a] [x (t:Maybe a)]) a]{
 
 Extracts the value inside @racket[x], producing a default value @racket[v] when @racket[x] is
-@racket[nothing]. Equivalent to @racket[(maybe v id)].
+@racket[Nothing]. Equivalent to @racket[(maybe v id)].
 
 @(hackett-examples
-  (eval:check (from-maybe 0 (just 5)) 5)
-  (eval:check (from-maybe 0 nothing) 0))}
+  (eval:check (from-maybe 0 (Just 5)) 5)
+  (eval:check (from-maybe 0 Nothing) 0))}
 
-@defdata[(Either a b) (left a) (right b)]{
+@defdata[(t:Either a b) (Left a) (Right b)]{
 
-A type that encodes the notion of a successful result or an error. The @racket[Functor],
-@racket[Applicative], and @racket[Monad] instances for @racket[(Either a)] are “right-biased”, so they
-will short-circuit on values wrapped in @racket[left] and will perform mapping or sequencing on values
-wrapped in @racket[right].
+A type that encodes the notion of a successful result or an error. The @racket[t:Functor],
+@racket[t:Applicate], and @racket[t:Monad] instances for @racket[(t:Either a)] are “right-biased”, so
+they will short-circuit on values wrapped in @racket[Left] and will perform mapping or sequencing on
+values wrapped in @racket[Right].
 
-This type is generally used in a similar way to @racket[Maybe], but it allows the sort of failure to
-be explicitly tagged, usually returning a error message or failure reason on the @racket[left] side.
-
-@(hackett-examples
-  (map (+ 1) (: (right 5) (Either String Integer)))
-  (map (+ 1) (: (left "an error happened") (Either String Integer))))}
-
-@defproc[(either [f {a -> c}] [g {b -> c}] [x (Either a b)]) c]{
-
-The catamorphism for @racket[Either]. Produces @racket[(f _y)] when @racket[x] is @racket[(left _y)]
-and produces @racket[(g _z)] when @racket[x] is @racket[(right _z)].
+This type is generally used in a similar way to @racket[t:Maybe], but it allows the sort of failure to
+be explicitly tagged, usually returning a error message or failure reason on the @racket[Left] side.
 
 @(hackett-examples
-  (eval:check (either (+ 1) (* 2) (left 5)) 6)
-  (eval:check (either (+ 1) (* 2) (right 5)) 10))}
+  (map (+ 1) (: (Right 5) (t:Either t:String t:Integer)))
+  (map (+ 1) (: (Left "an error happened") (t:Either t:String t:Integer))))}
 
-@defproc[(is-left [e (Either a b)]) Bool]{
+@defproc[(either [f {a t:-> c}] [g {b t:-> c}] [x (t:Either a b)]) c]{
 
-This predicate is @racket[true] when @racket[e] is of the form @racket[(left x)] for some @racket[x],
-and is false when @racket[e] is @racket[(right x)].
-
-@(hackett-examples
-  (eval:check (is-left (left "nifty")) true)
-  (eval:check (is-left (right "tubular")) false))}
-
-@defproc[(is-right [e (Either a b)]) Bool]{
-
-This predicate is @racket[true] when @racket[e] is of the form @racket[(right x)] for some @racket[x],
-and is false when @racket[e] is @racket[(left x)].
+The catamorphism for @racket[t:Either]. Produces @racket[(f _y)] when @racket[x] is @racket[(Left _y)]
+and produces @racket[(g _z)] when @racket[x] is @racket[(Right _z)].
 
 @(hackett-examples
-  (eval:check (is-right (left "nifty")) false)
-  (eval:check (is-right (right "tubular")) true))}
+  (eval:check (either (+ 1) (* 2) (Left 5)) 6)
+  (eval:check (either (+ 1) (* 2) (Right 5)) 10))}
 
-@defproc[(lefts [es (List (Either a b))]) (List a)]{
+@defproc[(is-left [e (t:Either a b)]) t:Bool]{
 
-Extract all values of the form @racket[(left x)] from es.
-
-@(hackett-examples
-  (lefts {(left 1) :: (right "haskell") :: (right "racket") :: (left -32) :: nil}))}
-
-@defproc[(rights [es (List (Either a b))]) (List b)]{
-
-Extract all values of the form @racket[(right x)] from es.
+This predicate is @racket[True] when @racket[e] is of the form @racket[(Left x)] for some @racket[x],
+and is @racket[False] when @racket[e] is @racket[(Right x)].
 
 @(hackett-examples
-  (rights {(left 1) :: (right "haskell") :: (right "racket") :: (left -32) :: nil}))}
+  (eval:check (is-left (Left "nifty")) True)
+  (eval:check (is-left (Right "tubular")) False))}
 
-@defproc[(partition-eithers [es (List (Either a b))]) (Tuple (List a) (List b))]{
+@defproc[(is-right [e (t:Either a b)]) t:Bool]{
 
-Extract every @racket[(left x)] to the first element of the pair and each @racket[(right x)] to the
-second. @racket[(partition-eithers es)] is equivalent to @racket[(tuple (lefts es) (rights es))]
+This predicate is @racket[True] when @racket[e] is of the form @racket[(Right x)] for some @racket[x],
+and is @racket[False] when @racket[e] is @racket[(Left x)].
 
 @(hackett-examples
-  (partition-eithers {(left 1) :: (right "haskell") :: (right "racket") :: (left -32) :: nil}))}
+  (eval:check (is-right (Left "nifty")) False)
+  (eval:check (is-right (Right "tubular")) True))}
+
+@defproc[(lefts [es (t:List (t:Either a b))]) (t:List a)]{
+
+Extract all values of the form @racket[(Left x)] from es.
+
+@(hackett-examples
+  (lefts {(Left 1) :: (Right "haskell") :: (Right "racket") :: (Left -32) :: Nil}))}
+
+@defproc[(rights [es (t:List (t:Either a b))]) (t:List b)]{
+
+Extract all values of the form @racket[(Right x)] from es.
+
+@(hackett-examples
+  (rights {(Left 1) :: (Right "haskell") :: (Right "racket") :: (Left -32) :: Nil}))}
+
+@defproc[(partition-eithers [es (t:List (t:Either a b))]) (t:Tuple (t:List a) (t:List b))]{
+
+Extract every @racket[(Left x)] to the first element of the pair and each @racket[(Right x)] to the
+second. @racket[(partition-eithers es)] is equivalent to @racket[(Tuple (lefts es) (rights es))]
+
+@(hackett-examples
+  (partition-eithers {(Left 1) :: (Right "haskell") :: (Right "racket") :: (Left -32) :: Nil}))}
 
 @subsection[#:tag "reference-lists"]{Lists}
 
-@defdata[(List a) (:: a (List a)) nil]{
+@defdata[(t:List a) (:: a (t:List a)) Nil]{
 
 The @deftech{list} type, which describes lazy linked lists. Since a list is lazy, it may be infinite,
 as long as the entire list is never demanded. The @racket[::] constructor is pronounced “cons”, and it
 is generally intended to be used infix.}
 
-@defthing[head (forall [a] {(List a) -> (Maybe a)})]{
+@defthing[head (t:forall [a] {(t:List a) t:-> (t:Maybe a)})]{
 
-Returns @racket[just] the first element of a list, or @racket[nothing] if the list is @racket[nil].
-
-@(hackett-examples
-  (head {1 :: 2 :: 3 :: nil})
-  (head (: nil (List Integer))))}
-
-@defthing[tail (forall [a] {(List a) -> (Maybe (List a))})]{
-
-Returns @racket[just] a list without its first element, or @racket[nothing] if the list is
-@racket[nil].
+Returns @racket[Just] the first element of a list, or @racket[Nothing] if the list is @racket[Nil].
 
 @(hackett-examples
-  (tail {1 :: 2 :: 3 :: nil})
-  (tail (: nil (List Integer))))}
+  (head {1 :: 2 :: 3 :: Nil})
+  (head (: Nil (t:List t:Integer))))}
 
-@defthing[head! (forall [a] {(List a) -> a})]{
+@defthing[tail (t:forall [a] {(t:List a) t:-> (t:Maybe (t:List a))})]{
+
+Returns @racket[Just] a list without its first element, or @racket[Nothing] if the list is
+@racket[Nil].
+
+@(hackett-examples
+  (tail {1 :: 2 :: 3 :: Nil})
+  (tail (: Nil (t:List t:Integer))))}
+
+@defthing[head! (t:forall [a] {(t:List a) t:-> a})]{
 
 A @tech[#:key "partial function"]{partial} version of @racket[head] that returns the first element of
 a list. If the list is empty, it raises an error.
 
 @(hackett-examples
-  (head! {1 :: 2 :: 3 :: nil})
-  (eval:error (head! (: nil (List Integer)))))}
+  (head! {1 :: 2 :: 3 :: Nil})
+  (eval:error (head! (: Nil (t:List t:Integer)))))}
 
-@defthing[tail! (forall [a] {(List a) -> (List a)})]{
+@defthing[tail! (t:forall [a] {(t:List a) t:-> (t:List a)})]{
 
 A @tech[#:key "partial function"]{partial} version of @racket[tail] that returns a list without its
 first element. If the list is empty, it raises an error.
 
 @(hackett-examples
-  (tail! {1 :: 2 :: 3 :: nil})
-  (eval:error (tail! (: nil (List Integer)))))}
+  (tail! {1 :: 2 :: 3 :: Nil})
+  (eval:error (tail! (: Nil (t:List t:Integer)))))}
 
-@defproc[(take [n Integer] [xs (List a)]) (List a)]{
+@defproc[(take [n t:Integer] [xs (t:List a)]) (t:List a)]{
 
 Produces a list with the first @racket[n] elements of @racket[xs]. If @racket[xs] contains fewer than
 @racket[n] elements, @racket[xs] is returned unmodified.
 
 @(hackett-examples
-  (take 2 {1 :: 2 :: 3 :: nil})
-  (take 2 {1 :: nil}))}
+  (take 2 {1 :: 2 :: 3 :: Nil})
+  (take 2 {1 :: Nil}))}
 
-@defproc[(drop [n Integer] [xs (List a)]) (List a)]{
+@defproc[(drop [n t:Integer] [xs (t:List a)]) (t:List a)]{
 
 Produces a list like @racket[xs] without its first @racket[n] elements. If @racket[xs] contains fewer
-then @racket[n] elements, the result is @racket[nil].
+then @racket[n] elements, the result is @racket[Nil].
 
 @(hackett-examples
-  (drop 2 {1 :: 2 :: 3 :: nil})
-  (drop 2 {1 :: nil}))}
+  (drop 2 {1 :: 2 :: 3 :: Nil})
+  (drop 2 {1 :: Nil}))}
 
-@defproc[(filter [f {a -> Bool}] [xs (List a)]) (List a)]{
+@defproc[(filter [f {a t:-> t:Bool}] [xs (t:List a)]) (t:List a)]{
 
 Produces a list that contains each element, @racket[_x], for which @racket[_x] is an element of
-@racket[xs] and @racket[(f _x)] is @racket[true].
+@racket[xs] and @racket[(f _x)] is @racket[True].
 
 @(hackett-examples
-  (filter (λ [x] {x > 5}) {3 :: 7 :: 2 :: 9 :: 12 :: 4 :: nil}))}
+  (filter (λ [x] {x > 5}) {3 :: 7 :: 2 :: 9 :: 12 :: 4 :: Nil}))}
 
-@defproc[(foldr [f {a -> b -> b}] [acc b] [xs (List a)]) b]{
+@defproc[(foldr [f {a t:-> b t:-> b}] [acc b] [xs (t:List a)]) b]{
 
 Reduces @racket[xs] to a single value using a right-associative binary operator, @racket[f], using
 @racket[acc] as a “seed” element. Uses of @racket[foldr] can be thought of as a series of nested,
@@ -696,12 +710,12 @@ the following expression:
   {_x0 f {_x1 f {_x2 f .... {_xn f acc} ....}}})
 
 @(hackett-examples
-  (foldr + 0 {1 :: 2 :: 3 :: 4 :: 5 :: nil})
-  (foldr * 1 {1 :: 2 :: 3 :: 4 :: 5 :: nil})
-  (foldr - 0 {1 :: 2 :: 3 :: 4 :: 5 :: nil})
-  (foldr :: nil {1 :: 2 :: 3 :: 4 :: 5 :: nil}))}
+  (foldr + 0 {1 :: 2 :: 3 :: 4 :: 5 :: Nil})
+  (foldr * 1 {1 :: 2 :: 3 :: 4 :: 5 :: Nil})
+  (foldr - 0 {1 :: 2 :: 3 :: 4 :: 5 :: Nil})
+  (foldr :: Nil {1 :: 2 :: 3 :: 4 :: 5 :: Nil}))}
 
-@defproc[(foldl [f {b -> a -> b}] [acc b] [xs (List a)]) b]{
+@defproc[(foldl [f {b t:-> a t:-> b}] [acc b] [xs (t:List a)]) b]{
 
 Reduces @racket[xs] to a single value using a left-associative binary operator, @racket[f], using
 @racket[acc] as a “seed” element. Uses of @racket[foldr] can be thought of as a series of nested,
@@ -713,27 +727,27 @@ the following expression:
   {.... {{{acc f _x0} f _x1} f _x2} .... _xn})
 
 @(hackett-examples
-  (foldl + 0 {1 :: 2 :: 3 :: 4 :: 5 :: nil})
-  (foldl * 1 {1 :: 2 :: 3 :: 4 :: 5 :: nil})
-  (foldl - 0 {1 :: 2 :: 3 :: 4 :: 5 :: nil}))}
+  (foldl + 0 {1 :: 2 :: 3 :: 4 :: 5 :: Nil})
+  (foldl * 1 {1 :: 2 :: 3 :: 4 :: 5 :: Nil})
+  (foldl - 0 {1 :: 2 :: 3 :: 4 :: 5 :: Nil}))}
 
-@defproc[(sum [xs (List Integer)]) Integer]{
+@defproc[(sum [xs (t:List t:Integer)]) t:Integer]{
 
 Adds the elements of @racket[xs] together and returns the sum. Equivalent to @racket[(foldl + 0)].
 
 @(hackett-examples
-  (eval:check (sum {1 :: 2 :: 3 :: nil}) 6)
-  (eval:check (sum nil) 0))}
+  (eval:check (sum {1 :: 2 :: 3 :: Nil}) 6)
+  (eval:check (sum Nil) 0))}
 
 @section[#:tag "reference-typeclasses"]{Typeclasses}
 
 @subsection[#:tag "reference-defining-typeclasses"]{Defining typeclasses and typeclass instances}
 
-@defform[#:literals [: =>]
+@defform[#:literals [: t:=>]
          (class maybe-superclasses (class-id var-id ...)
            [method-id : method-type maybe-default-method-impl] ...)
          #:grammar
-         ([maybe-superclasses (code:line superclass-constraint ... =>)
+         ([maybe-superclasses (code:line superclass-constraint ... t:=>)
                               (code:line)]
           [maybe-default-method-impl default-method-impl-expr
                                      (code:line)])]{
@@ -755,14 +769,14 @@ typeclass method may be defined in terms of other typeclass methods, but the imp
 a choice of which methods to implement, or they can provide a more efficient implementation for
 commonly-used methods.}
 
-@defform[#:literals [forall =>]
+@defform[#:literals [t:forall t:=>]
          (instance instance-spec
            [method-id method-expr] ...)
          #:grammar
          ([instance-spec (class-id instance-type ...)
-                         (forall [var-id ...] maybe-constraints
-                                 (class-id instance-type ...))]
-          [maybe-constraints (code:line instance-constraint ... =>)
+                         (t:forall [var-id ...] maybe-constraints
+                                   (class-id instance-type ...))]
+          [maybe-constraints (code:line instance-constraint ... t:=>)
                              (code:line)])]{
 
 Defines a @deftech{typeclass instance}, which declares that the given @racket[instance-type]s belong
@@ -770,47 +784,47 @@ to the @tech{typeclass} bound to @racket[class-id].}
 
 @subsection[#:tag "reference-show"]{Printing for debugging}
 
-@defclass[(Show a)
-          [show {a -> String}]]{
+@defclass[(t:Show a)
+          [show {a t:-> t:String}]]{
 
-A class for converting values to @racket[String] representations for the purposes of debugging.
-Generally, the @racket[Show] instance for a type should produce a valid Hackett expression that, when
+A class for converting values to @racket[t:String] representations for the purposes of debugging.
+Generally, the @racket[t:Show] instance for a type should produce a valid Hackett expression that, when
 evaluated, produces the value.
 
-@defmethod[show {a -> String}]{
+@defmethod[show {a t:-> t:String}]{
 
 @(hackett-examples
   (show 42)
   (show "hello")
-  (show (just 11))
-  (show {1 :: 2 :: 3 :: nil}))}}
+  (show (Just 11))
+  (show {1 :: 2 :: 3 :: Nil}))}}
 
 @subsection[#:tag "reference-equality"]{Equality}
 
-@defclass[(Eq a)
-          [== {a -> a -> Bool}]]{
-The class of types with a notion of equality. The @racket[==] method should produce @racket[true] if
-both of its arguments are equal, otherwise it should produce @racket[false].
+@defclass[(t:Eq a)
+          [== {a t:-> a t:-> t:Bool}]]{
+The class of types with a notion of equality. The @racket[==] method should produce @racket[True] if
+both of its arguments are equal, otherwise it should produce @racket[False].
 
-@defmethod[== {a -> a -> Bool}]{
+@defmethod[== {a t:-> a t:-> t:Bool}]{
 
 @(hackett-examples
-  (eval:check {10 == 10} true)
-  (eval:check {10 == 11} false)
-  (eval:check {{1 :: 2 :: nil} == {1 :: 2 :: nil}} true)
-  (eval:check {{1 :: 2 :: nil} == {1 :: nil}} false)
-  (eval:check {{1 :: 2 :: nil} == {1 :: 3 :: nil}} false))}}
+  (eval:check {10 == 10} True)
+  (eval:check {10 == 11} False)
+  (eval:check {{1 :: 2 :: Nil} == {1 :: 2 :: Nil}} True)
+  (eval:check {{1 :: 2 :: Nil} == {1 :: Nil}} False)
+  (eval:check {{1 :: 2 :: Nil} == {1 :: 3 :: Nil}} False))}}
 
 @subsection[#:tag "reference-semigroup-monoid"]{Semigroups and monoids}
 
-@defclass[(Semigroup a)
-          [++ {a -> a -> a}]]{
+@defclass[(t:Semigroup a)
+          [++ {a t:-> a t:-> a}]]{
 
 The class of @deftech{semigroups}, types with an associative binary operation, @racket[++]. Generally,
 @racket[++] defines some notion of combining or appending, as is the case with the instances for
-@racket[String] and @racket[(List _a)], but this is not necessarily true.
+@racket[t:String] and @racket[(t:List _a)], but this is not necessarily true.
 
-@defmethod[++ {a -> a -> a}]{
+@defmethod[++ {a t:-> a t:-> a}]{
 
 An associative operation. That is, @racket[++] must obey the following law:
 
@@ -819,10 +833,10 @@ An associative operation. That is, @racket[++] must obey the following law:
 
 @(hackett-examples
   {"hello" ++ ", " ++ "world!"}
-  {{1 :: 2 :: nil} ++ {3 :: 4 :: nil}})}}
+  {{1 :: 2 :: Nil} ++ {3 :: 4 :: Nil}})}}
 
-@defclass[#:super [(Semigroup a)]
-          (Monoid a)
+@defclass[#:super [(t:Semigroup a)]
+          (t:Monoid a)
           [mempty a]]{
 
 A @deftech{monoid} extends the notion of a @tech{semigroup} with the notion of an identity element,
@@ -837,26 +851,26 @@ An identity element for @racket[++]. That is, @racket[mempty] must obey the foll
   @#,racket[{mempty ++ _a}] @#,elem[#:style 'roman]{=} @#,racket[_a]]
 
 @(hackett-examples
-  (: mempty String)
-  (: mempty (List Integer)))}}
+  (: mempty t:String)
+  (: mempty (t:List t:Integer)))}}
 
 @subsection[#:tag "reference-functor"]{Functors}
 
-@defclass[(Functor f)
-          [map (forall [a b] {{a -> b} -> (f a) -> (f b)})]]{
+@defclass[(t:Functor f)
+          [map (t:forall [a b] {{a t:-> b} t:-> (f a) t:-> (f b)})]]{
 
 A class of types that are @deftech{functors}, essentially types that provide a mapping or “lifting”
 operation. The @racket[map] function can be viewed in different ways:
 
   @itemlist[
     @item{The @racket[map] function can be thought of as applying a function to each “element” of some
-          “container”. This metaphor applies to many members of the @racket[Functor] typeclass, such
-          as @racket[List] and @racket[Maybe], but does not apply well to all of them.}
+          “container”. This metaphor applies to many members of the @racket[t:Functor] typeclass, such
+          as @racket[t:List] and @racket[t:Maybe], but does not apply well to all of them.}
 
     @item{More generally, @racket[map] can be viewed as a “lifting” operation, which “lifts” a
-          function of type @racket[{_a -> _b}] to a function of type @racket[{(f _a) -> (f _b)}] for
-          some type @racket[f]. This is a very general notion, and the meaning of such an operation is
-          highly dependent on the particular choice of @racket[f].}]
+          function of type @racket[{_a t:-> _b}] to a function of type @racket[{(f _a) t:-> (f _b)}]
+          for some type @racket[f]. This is a very general notion, and the meaning of such an
+          operation is highly dependent on the particular choice of @racket[f].}]
 
 All @racket[map] implementations must obey the following laws:
 
@@ -864,51 +878,51 @@ All @racket[map] implementations must obey the following laws:
   @#,racket[(map id)] @#,elem[#:style 'roman]{=} @#,racket[id]
   @#,racket[(map {_f |.| _g}) @#,elem[#:style 'roman]{=} @#,racket[{(map _f) |.| (map _g)}]]]
 
-@defmethod[map (forall [a b] {{a -> b} -> (f a) -> (f b)})]{
+@defmethod[map (t:forall [a b] {{a t:-> b} t:-> (f a) t:-> (f b)})]{
 
 @(hackett-examples
-  (map (+ 1) {1 :: 2 :: nil})
-  (map (+ 1) (just 10))
-  (map (+ 1) nothing))}}
+  (map (+ 1) {1 :: 2 :: Nil})
+  (map (+ 1) (Just 10))
+  (map (+ 1) Nothing))}}
 
-@defthing[<$> (forall [f a b] (Functor f) => {{a -> b} -> (f a) -> (f b)})]{
+@defthing[<$> (t:forall [f a b] (t:Functor f) t:=> {{a t:-> b} t:-> (f a) t:-> (f b)})]{
 
 An alias for @racket[map], intended to be used in @tech{infix mode} instead of prefix, especially when
 mixed with @racket[<*>] in the same expression.
 
 @(hackett-examples
-  {(+ 1) <$> {1 :: 2 :: nil}}
-  {(+ 1) <$> (just 10)}
-  {(+ 1) <$> nothing})}
+  {(+ 1) <$> {1 :: 2 :: Nil}}
+  {(+ 1) <$> (Just 10)}
+  {(+ 1) <$> Nothing})}
 
-@defthing[<&> (forall [f a b] (Functor f) => {(f a) -> {a -> b} -> (f b)})]{
+@defthing[<&> (t:forall [f a b] (t:Functor f) t:=> {(f a) t:-> {a t:-> b} t:-> (f b)})]{
 
 A flipped version of @racket[<$>] for when it’s preferable to take the function argument second, like
 @racket[&] but lifted to a @tech{functor}.}
 
-@defthing[<$ (forall [f a b] (Functor f) => {b -> (f a) -> (f b)})]{
+@defthing[<$ (t:forall [f a b] (t:Functor f) t:=> {b t:-> (f a) t:-> (f b)})]{
 
 Equivalent to @racket[{map |.| const}]. Replaces all values of type @racket[_a] with a new value of
 type @racket[_b].
 
 @(hackett-examples
-  {10 <$ (just 1)}
-  {10 <$ {1 :: 2 :: 3 :: nil}})}
+  {10 <$ (Just 1)}
+  {10 <$ {1 :: 2 :: 3 :: Nil}})}
 
-@defthing[$> (forall [f a b] (Functor f) => {(f a) -> b -> (f b)})]{
+@defthing[$> (t:forall [f a b] (t:Functor f) t:=> {(f a) t:-> b t:-> (f b)})]{
 
 A flipped version of @racket[<$].}
 
-@defthing[ignore (forall [f a] (Functor f) => {(f a) -> (f Unit)})]{
+@defthing[ignore (t:forall [f a] (t:Functor f) t:=> {(f a) t:-> (f t:Unit)})]{
 
-Replaces the result of a @tech{functor} with @racket[unit]. Equivalent to @racket[(<$ unit)].}
+Replaces the result of a @tech{functor} with @racket[Unit]. Equivalent to @racket[(<$ Unit)].}
 
 @subsection[#:tag "reference-applicative"]{Applicative functors}
 
-@defclass[#:super [(Functor f)]
-          (Applicative f)
-          [pure (forall [a] {a -> (f a)})]
-          [<*> (forall [a b] {(f {a -> b}) -> (f a) -> (f b)})]]{
+@defclass[#:super [(t:Functor f)]
+          (t:Applicative f)
+          [pure (t:forall [a] {a t:-> (f a)})]
+          [<*> (t:forall [a b] {(f {a t:-> b}) t:-> (f a) t:-> (f b)})]]{
 
 The class of @deftech{applicative functors}, which are @tech{functors} with some notion of
 application, @racket[<*>]. Additionally, applicative functors must provided a lifting operation,
@@ -922,70 +936,71 @@ Applicative functors must satisfy the following laws:
   @#,racket[{(pure _f) <*> (pure _x)}] @#,elem[#:style 'roman]{=} @#,racket[(pure (_f _x))]
   @#,racket[{_u <*> (pure _y)}] @#,elem[#:style 'roman]{=} @#,racket[{(pure (& _y) <*> _u)}]]
 
-As a consequence of these laws, the @racket[Functor] instance for @racket[f] will satisfy:
+As a consequence of these laws, the @racket[t:Functor] instance for @racket[f] will satisfy:
 
 @racketblock[
   @#,racket[(map _f _x)] @#,elem[#:style 'roman]{=} @#,racket[{(pure _f) <*> _x}]]
 
-@defmethod[pure (forall [a] {a -> (f a)})]{
+@defmethod[pure (t:forall [a] {a t:-> (f a)})]{
 
 Lifts a value.
 
 @(hackett-examples
-  (: (pure 11) (Maybe Integer))
-  (: (pure 11) (List Integer)))}
+  (: (pure 11) (t:Maybe t:Integer))
+  (: (pure 11) (t:List t:Integer)))}
 
-@defmethod[<*> (forall [a b] {(f {a -> b}) -> (f a) -> (f b)})]{
+@defmethod[<*> (t:forall [a b] {(f {a t:-> b}) t:-> (f a) t:-> (f b)})]{
 
 Applies a function in a context. While @racket[map]/@racket[<$>] “lifts” a pure function to a function
 that operates on a functor, @racket[<*>] applies a function that is already inside the context of a
 @tech{functor}.
 
 @(hackett-examples
-  {(just not) <*> (just true)}
-  {(just not) <*> (just false)}
-  {(just not) <*> nothing}
-  {(: nothing (Maybe {Bool -> Bool})) <*> (just true)})
+  {(Just not) <*> (Just True)}
+  {(Just not) <*> (Just False)}
+  {(Just not) <*> Nothing}
+  {(: Nothing (t:Maybe {t:Bool t:-> t:Bool})) <*> (Just True)})
 
 Due to currying, this is especially useful in combination with @racket[<$>] to apply a multi-argument
-function to multiple arguments within the context of some functor. For example, @racket[Maybe]
-implements a sort of short-circuiting, where any @racket[nothing] will cause the entire computation to
-produce @racket[nothing].
+function to multiple arguments within the context of some functor. For example, @racket[t:Maybe]
+implements a sort of short-circuiting, where any @racket[Nothing] will cause the entire computation to
+produce @racket[Nothing].
 
 @(hackett-examples
-  {+ <$> (just 1) <*> (just 2)}
-  {+ <$> nothing <*> (just 2)}
-  {+ <$> (just 1) <*> nothing})
+  {+ <$> (Just 1) <*> (Just 2)}
+  {+ <$> Nothing <*> (Just 2)}
+  {+ <$> (Just 1) <*> Nothing})
 
 This works because @racket[{_f <$> _x}] is guaranteed to be equivalent to @racket[{(pure _f) <*> _x}]
 by the applicative laws, and since functions are curried, each use of @racket[<*>] applies a single
 argument to the (potentially partially-applied) function.}}
 
-@defthing[sequence (forall [f a] (Applicative f) => {(List (f a)) -> (f (List a))})]{
+@defthing[sequence (t:forall [f a] (t:Applicate f) t:=> {(t:List (f a)) t:-> (f (t:List a))})]{
 
 Produces an action that runs a @tech{list} of @tech[#:key "applicative functor"]{applicative} actions
 from left to right, then collects the results into a new list.
 
 @(hackett-examples
-  (sequence {(just 1) :: (just 2) :: (just 3) :: nil})
-  (sequence {(just 1) :: nothing :: (just 3) :: nil}))}
+  (sequence {(Just 1) :: (Just 2) :: (Just 3) :: Nil})
+  (sequence {(Just 1) :: Nothing :: (Just 3) :: Nil}))}
 
-@defthing[traverse (forall [f a b] (Applicative f) => {{a -> (f b)} -> (List a) -> (f (List b))})]{
+@defthing[traverse
+          (t:forall [f a b] (t:Applicate f) t:=> {{a t:-> (f b)} t:-> (t:List a) t:-> (f (t:List b))})]{
 
 Applies a function to each element of a @tech{list} to produce an @tech[#:key "applicative functor"]{
 applicative} action, then collects them left to right @italic{a la} @racket[sequence]
 (@racket[(traverse _f _xs)] is equivalent to @racket[(sequence (map _f _xs))]).
 
 @(hackett-examples
-  (traverse head {{1 :: nil} :: {2 :: 3 :: nil} :: nil})
-  (traverse head {{1 :: nil} :: nil :: nil}))}
+  (traverse head {{1 :: Nil} :: {2 :: 3 :: Nil} :: Nil})
+  (traverse head {{1 :: Nil} :: Nil :: Nil}))}
 
 @subsection[#:tag "reference-monad"]{Monads}
 
-@defclass[#:super [(Applicative m)]
-          (Monad m)
-          [join (forall [a] {(m (m a)) -> (m a)})]
-          [=<< (forall [a b] {{a -> (m b)} -> (m a) -> (m b)})]]{
+@defclass[#:super [(t:Applicate m)]
+          (t:Monad m)
+          [join (t:forall [a] {(m (m a)) t:-> (m a)})]
+          [=<< (t:forall [a b] {{a t:-> (m b)} t:-> (m a) t:-> (m b)})]]{
 
 The class of @deftech{monads}, which are @tech{applicative functors} augmented with a single
 @racket[join] operation that allows multiple “layers” of @racket[m] to be “flattened” into a single
@@ -1007,15 +1022,15 @@ if a more efficient implementation can be provided.
 
 It is often more useful to use @racket[do] than to use @racket[join] or @racket[=<<] directly.
 
-@defmethod[join (forall [a] {(m (m a)) -> (m a)})]{
+@defmethod[join (t:forall [a] {(m (m a)) t:-> (m a)})]{
 
 @(hackett-examples
-  (join (just (just 3)))
-  (join (just (: nothing (Maybe Integer))))
-  (join (: nothing (Maybe (Maybe Integer))))
-  (join {{1 :: nil} :: {2 :: 3 :: nil} :: nil}))}
+  (join (Just (Just 3)))
+  (join (Just (: Nothing (t:Maybe t:Integer))))
+  (join (: Nothing (t:Maybe (t:Maybe t:Integer))))
+  (join {{1 :: Nil} :: {2 :: 3 :: Nil} :: Nil}))}
 
-@defmethod[=<< (forall [a b] {{a -> (m b)} -> (m a) -> (m b)})]{
+@defmethod[=<< (t:forall [a b] {{a t:-> (m b)} t:-> (m a) t:-> (m b)})]{
 
 Applies a function that produces a monadic value to a monadic value. The expression
 @racket[{_f =<< _x}] is equivalent to @racket[(join {_f <$> _x})] (and an explicit implementation of
@@ -1024,11 +1039,11 @@ both methods must maintain that law). It is worth comparing and contrasting the 
 different.
 
 @(hackett-examples
-  {head =<< (tail {1 :: 2 :: nil})}
-  {head =<< (tail {1 :: nil})}
-  {head =<< (tail (: nil (List Integer)))})}}
+  {head =<< (tail {1 :: 2 :: Nil})}
+  {head =<< (tail {1 :: Nil})}
+  {head =<< (tail (: Nil (t:List t:Integer)))})}}
 
-@defthing[>>= (forall [m a b] (Monad m) => {(m a) -> {a -> (m b)} -> (m b)})]{
+@defthing[>>= (t:forall [m a b] (t:Monad m) t:=> {(m a) t:-> {a t:-> (m b)} t:-> (m b)})]{
 
 A flipped version of @racket[=<<].}
 
@@ -1041,7 +1056,7 @@ A flipped version of @racket[=<<].}
 A convenient, imperative-style shorthand for a sequence of monadic expressions chained together with
 @racket[>>=]. Each @racket[do-clause] corresponds to a single use of @racket[>>=], and each
 @racket[monadic-expr] must have a type with the shape @racket[(_m _a)], where @racket[_m] is a
-@racket[Monad].
+@racket[t:Monad].
 
 Any use of @racket[do] with a single subform expands to the subform: @racket[(do _expr)] is equivalent
 to @racket[_expr]. Each @racket[do-clause] introduces a use of @racket[>>=], with the result
@@ -1053,16 +1068,16 @@ This is often much more readable than writing the uses of @racket[>>=] out by ha
 the result of each action must be give a name.
 
 @(hackett-examples
-  (do [xs <- (tail {1 :: 2 :: 3 :: 4 :: nil})]
+  (do [xs <- (tail {1 :: 2 :: 3 :: 4 :: Nil})]
       [ys <- (tail xs)]
       [zs <- (tail ys)]
       (head zs))
-  (do [xs <- (tail {1 :: 2 :: 3 :: nil})]
+  (do [xs <- (tail {1 :: 2 :: 3 :: Nil})]
       [ys <- (tail xs)]
       [zs <- (tail ys)]
       (head zs)))}
 
-@defthing[ap (forall [m a b] (Monad m) => {(m {a -> b}) -> (m a) -> (m b)})]{
+@defthing[ap (t:forall [m a b] (t:Monad m) t:=> {(m {a t:-> b}) t:-> (m a) t:-> (m b)})]{
 
 An implementation of @racket[<*>] in terms of @racket[map], @racket[pure], and @racket[join]. This can
 be used as an implementation of @racket[<*>] as long as @racket[join] does not use @racket[<*>] (if it
@@ -1079,8 +1094,8 @@ runtime to perform the actual I/O actions described by the @racket[IO] value.
 
 It may be helpful to think of a value of type @racket[(IO a)] as a set of @emph{instructions} to
 obtain a value of type @racket[a]. This makes it clear that it is @bold{impossible} to get the value
-“inside” an @racket[IO] action, since no such value exists; there is no @racket[String] “inside” a
-value of type @racket[(IO String)].
+“inside” an @racket[IO] action, since no such value exists; there is no @racket[t:String] “inside” a
+value of type @racket[(IO t:String)].
 
 Since @racket[main] is the only way to ask the runtime to execute the instructions contained within
 an @racket[IO] action, and @racket[main] is only legal at the top level of a module, it is impossible
@@ -1100,11 +1115,11 @@ Uses of this form correspond to definitions of @racketid[main] submodules in @ha
 @racketmodname[racket]. For more information, see
 @secref["main-and-test" #:doc '(lib "scribblings/guide/guide.scrbl")].}
 
-@defproc[(print [str String]) (IO Unit)]{
+@defproc[(print [str t:String]) (IO t:Unit)]{
 
 Produces an @tech{I/O action} that prints @racket[str] to standard output.}
 
-@defproc[(println [str String]) (IO Unit)]{
+@defproc[(println [str t:String]) (IO t:Unit)]{
 
 Like @racket[print], but appends a newline to the end of the printed message.}
 
@@ -1112,8 +1127,8 @@ Like @racket[print], but appends a newline to the end of the printed message.}
 
 @defmodule[hackett/monad/trans]
 
-@defclass[(MonadTrans t)
-          [lift (forall [m a] {(m a) -> (t m a)})]]{
+@defclass[(t:MonadTrans t)
+          [lift (t:forall [m a] {(m a) t:-> (t m a)})]]{
 
 The class of @deftech{monad transformers}. A monad transformer builds a new monad from an existing
 one, extending it with additional functionality. In this sense, monad transformers can be thought of
@@ -1125,7 +1140,7 @@ Instances should satisfy the following laws:
   @#,racket[{lift |.| pure}] @#,elem[#:style 'roman]{=} @#,racket[pure]
   @#,racket[(lift {_m >>= _f})] @#,elem[#:style 'roman]{=} @#,racket[{(lift _m) >>= {lift |.| _f}}]]
 
-@defmethod[lift (forall [m a] {(m a) -> (t m a)})]{
+@defmethod[lift (t:forall [m a] {(m a) t:-> (t m a)})]{
 
 Lifts a computation from the argument monad to the constructed monad.}}
 
@@ -1133,7 +1148,7 @@ Lifts a computation from the argument monad to the constructed monad.}}
 
 @defmodule[hackett/monad/reader]
 
-@defdata[(ReaderT r m a) (reader-t {r -> (m a)})]{
+@defdata[(t:ReaderT r m a) (reader-t {r t:-> (m a)})]{
 
 The @deftech{reader monad transformer}, a @tech{monad transformer} that extends a monad with a
 read-only dynamic environment. The environment can be accessed with @racket[ask] and locally modified
@@ -1141,21 +1156,21 @@ with @racket[local].
 
 @(hackett-interaction
   (run-reader-t (do [x <- ask]
-                    [y <- (lift {{x + 1} :: {x - 1} :: nil})]
-                    (lift {{y * 2} :: {y * 3} :: nil}))
+                    [y <- (lift {{x + 1} :: {x - 1} :: Nil})]
+                    (lift {{y * 2} :: {y * 3} :: Nil}))
                 10))}
 
-@defproc[(run-reader-t [x (ReaderT r m a)] [ctx r]) (m a)]{
+@defproc[(run-reader-t [x (t:ReaderT r m a)] [ctx r]) (m a)]{
 
 Runs the @tech{reader monad transformer} computation @racket[x] with the context @racket[ctx] and
 produces a computation in the argument monad.}
 
-@defproc[(run-reader [x (ReaderT r Identity a)] [ctx r]) a]{
+@defproc[(run-reader [x (t:ReaderT r t:Identity a)] [ctx r]) a]{
 
 Runs the @tech{reader monad transformer} computation @racket[x] with the context @racket[ctx] and
 extracts the result.}
 
-@defthing[ask (forall [r m] (ReaderT r m r))]{
+@defthing[ask (t:forall [r m] (t:ReaderT r m r))]{
 
 A computation that fetches the value of the current dynamic environment.
 
@@ -1163,16 +1178,16 @@ A computation that fetches the value of the current dynamic environment.
   (eval:check (run-reader ask 5) 5)
   (eval:check (run-reader ask "hello") "hello"))}
 
-@defproc[(asks [f {r -> a}]) (ReaderT r m a)]{
+@defproc[(asks [f {r t:-> a}]) (t:ReaderT r m a)]{
 
 Produces a computation that fetches a value from the current dynamic environment, applies @racket[f]
 to it, and returns the result.
 
 @(hackett-interaction
   (eval:check (run-reader (asks (+ 1)) 5) 6)
-  (eval:check (run-reader (asks head) {5 :: nil}) (just 5)))}
+  (eval:check (run-reader (asks head) {5 :: Nil}) (Just 5)))}
 
-@defproc[(local [f {r -> r}] [x (ReaderT r m a)]) (ReaderT r m a)]{
+@defproc[(local [f {r t:-> r}] [x (t:ReaderT r m a)]) (t:ReaderT r m a)]{
 
 Produces a computation like @racket[x], except that the environment is modified in its dynamic extent
 by applying @racket[f] to it.}
@@ -1181,7 +1196,7 @@ by applying @racket[f] to it.}
 
 @defmodule[hackett/monad/error]
 
-@defdata[(ErrorT e m a) (error-t (m (Either e a)))]{
+@defdata[(t:ErrorT e m a) (ErrorT (m (t:Either e a)))]{
 
 The @deftech{error monad transformer}, a @tech{monad transformer} that extends a monad with a notion
 of failure. Failures short-circuit other computations in the monad, and they can carry information,
@@ -1196,53 +1211,53 @@ usually information about what caused the failure.
                                (throw "Oops!")
                                (lift (println "Never gets here.")))))))}
 
-@defproc[(run-error-t [x (ErrorT e m a)]) (m (Either e a))]{
+@defproc[(run-error-t [x (t:ErrorT e m a)]) (m (t:Either e a))]{
 
 Runs the @tech{error monad transformer} computation @racket[x] and produces the possibly-aborted
 result in the argument monad.}
 
-@defproc[(run-error [x (ErrorT e Identity a)]) (Either e a)]{
+@defproc[(run-error [x (t:ErrorT e t:Identity a)]) (t:Either e a)]{
 
 Runs the @tech{error monad transformer} computation @racket[x] and extracts the possibly-aborted
 result.}
 
-@defproc[(throw [ex e]) (ErrorT e m a)]{
+@defproc[(throw [ex e]) (t:ErrorT e m a)]{
 
 Produces a computation that raises @racket[ex] as an error, aborting the current computation (unless
 caught with @racket[catch]).
 
 @(hackett-interaction
-  (eval:check (: (run-error (pure 42)) (Either String Integer))
-              (: (right 42) (Either String Integer)))
+  (eval:check (: (run-error (pure 42)) (t:Either t:String t:Integer))
+              (: (Right 42) (t:Either t:String t:Integer)))
   (eval:check (run-error (do (throw "Ack!") (pure 42)))
-              (: (left "Ack!") (Either String Integer))))}
+              (: (Left "Ack!") (t:Either t:String t:Integer))))}
 
-@defproc[(catch [x (ErrorT e m a)] [handler {e -> (ErrorT e* m a)}]) (ErrorT e* m a)]{
+@defproc[(catch [x (t:ErrorT e m a)] [handler {e t:-> (t:ErrorT e* m a)}]) (t:ErrorT e* m a)]{
 
 Produces a computation like @racket[x], except any errors raised are handled via @racket[handler]
 instead of immediately aborting.
 
 @(hackett-interaction
-  (eval:check (: (run-error (throw "Ack!")) (Either String String))
-              (: (left "Ack!") (Either String String)))
+  (eval:check (: (run-error (throw "Ack!")) (t:Either t:String t:String))
+              (: (Left "Ack!") (t:Either t:String t:String)))
   (eval:check (: (run-error (catch (throw "Ack!")
                               (λ [str] (pure {"Caught error: " ++ str}))))
-                 (Either Unit String))
-              (: (right "Caught error: Ack!") (Either Unit String))))}
+                 (t:Either t:Unit t:String))
+              (: (Right "Caught error: Ack!") (t:Either t:Unit t:String))))}
 
 @section[#:tag "reference-controlling-evaluation"]{Controlling Evaluation}
 
-@defthing[seq (forall [a b] {a -> b -> b})]{
+@defthing[seq (t:forall [a b] {a t:-> b t:-> b})]{
 
 Accepts two arguments and returns its second argument. When the result is forced, the first argument
 will also be evaluated to weak head normal form. This can be used to reduce laziness.}
 
-@defthing[error! (forall [a] {String -> a})]{
+@defthing[error! (t:forall [a] {t:String t:-> a})]{
 
 @see-guide-note["guide-bottoms"]{partial functions}
 
 A simple @tech{partial function} that crashes the program with a message when evaluated.}
 
-@defthing[undefined! (forall [a] a)]{
+@defthing[undefined! (t:forall [a] a)]{
 
 A @tech[#:key "partial function"]{partial} value that crashes the program when evaluated.}

--- a/hackett-lib/hackett/base.rkt
+++ b/hackett-lib/hackett/base.rkt
@@ -14,4 +14,6 @@
 
 (module reader syntax/module-reader hackett/base
   #:wrapper1 call-with-hackett-reading-parameterization
-  (require hackett/private/reader))
+  #:module-wrapper module-wrapper-insert-type-require
+  (require hackett/private/reader
+           (submod hackett/private/kernel module-wrapper)))

--- a/hackett-lib/hackett/data/either.rkt
+++ b/hackett-lib/hackett/data/either.rkt
@@ -5,30 +5,30 @@
 (provide (data Either) either is-left is-right lefts rights partition-eithers)
 
 (defn either : (∀ [a b c] {{a -> c} -> {b -> c} -> (Either a b) -> c})
-  [[f _ (left  x)] (f x)]
-  [[_ g (right y)] (g y)])
+  [[f _ (Left  x)] (f x)]
+  [[_ g (Right y)] (g y)])
 
 (defn is-left : (forall [l r] {(Either l r) -> Bool})
-  [[(left _)]  true]
-  [[(right _)] false])
+  [[(Left _)]  True]
+  [[(Right _)] False])
 
 (defn is-right : (forall [l r] {(Either l r) -> Bool})
-  [[(left _)]  false]
-  [[(right _)] true])
+  [[(Left _)]  False]
+  [[(Right _)] True])
 
 (defn lefts : (forall [l r] {(List (Either l r)) -> (List l)})
   [[{e :: es}] (case e
-                 [(left x) {x :: (lefts es)}]
+                 [(Left x) {x :: (lefts es)}]
                  [_        (lefts es)])]
-  [[nil] nil])
+  [[Nil] Nil])
 
 (defn rights : (forall [l r] {(List (Either l r)) -> (List r)})
   [[{e :: es}] (case e
-                 [(right x) {x :: (rights es)}]
+                 [(Right x) {x :: (rights es)}]
                  [_         (rights es)])]
-  [[nil] nil])
+  [[Nil] Nil])
 
 (def partition-eithers : (forall [l r] {(List (Either l r)) -> (Tuple (List l) (List r))})
-  (foldr (λ* [[(left x)  (tuple ls rs)] (tuple {x :: ls} rs)]
-             [[(right x) (tuple ls rs)] (tuple ls {x :: rs})])
-         (tuple nil nil)))
+  (foldr (λ* [[(Left x)  (Tuple ls rs)] (Tuple {x :: ls} rs)]
+             [[(Right x) (Tuple ls rs)] (Tuple ls {x :: rs})])
+         (Tuple Nil Nil)))

--- a/hackett-lib/hackett/data/identity.rkt
+++ b/hackett-lib/hackett/data/identity.rkt
@@ -2,29 +2,29 @@
 
 (provide (data Identity) run-identity)
 
-(data (Identity a) (identity a))
+(data (Identity a) (Identity a))
 
 (defn run-identity : (forall [a] {(Identity a) -> a})
-  [[(identity x)] x])
+  [[(Identity x)] x])
 
 (instance (forall [a] (Show a) => (Show (Identity a)))
-  [show (λ [(identity x)] {"(identity " ++ (show x) ++ ")"})])
+  [show (λ [(Identity x)] {"(Identity " ++ (show x) ++ ")"})])
 
 (instance (forall [a] (Eq a) => (Eq (Identity a)))
-  [== (λ [(identity x) (identity y)] {x == y})])
+  [== (λ [(Identity x) (Identity y)] {x == y})])
 
 (instance (forall [a] (Semigroup a) => (Semigroup (Identity a)))
-  [++ (λ [(identity x) (identity y)] (identity {x ++ y}))])
+  [++ (λ [(Identity x) (Identity y)] (Identity {x ++ y}))])
 
 (instance (forall [a] (Monoid a) => (Monoid (Identity a)))
-  [mempty (identity mempty)])
+  [mempty (Identity mempty)])
 
 (instance (Functor Identity)
-  [map (λ [f (identity x)] (identity (f x)))])
+  [map (λ [f (Identity x)] (Identity (f x)))])
 
 (instance (Applicative Identity)
-  [pure identity]
-  [<*> (λ [(identity f) (identity x)] (identity (f x)))])
+  [pure Identity]
+  [<*> (λ [(Identity f) (Identity x)] (Identity (f x)))])
 
 (instance (Monad Identity)
-  [join (λ [(identity (identity x))] (identity x))])
+  [join (λ [(Identity (Identity x))] (Identity x))])

--- a/hackett-lib/hackett/data/list.rkt
+++ b/hackett-lib/hackett/data/list.rkt
@@ -7,12 +7,12 @@
          repeat cycle! or and any? all? elem? not-elem? delete delete-by)
 
 (defn head : (∀ [a] {(List a) -> (Maybe a)})
-  [[{x :: _}] (just x)]
-  [[nil     ] nothing])
+  [[{x :: _}] (Just x)]
+  [[Nil     ] Nothing])
 
 (defn tail : (∀ [a] {(List a) -> (Maybe (List a))})
-  [[{_ :: xs}] (just xs)]
-  [[nil      ] nothing])
+  [[{_ :: xs}] (Just xs)]
+  [[Nil      ] Nothing])
 
 (defn head! : (∀ [a] {(List a) -> a})
   [[xs] (from-maybe (error! "head!: empty list") (head xs))])
@@ -23,33 +23,33 @@
 (defn take : (∀ [a] {Integer -> (List a) -> (List a)})
   [[n {x :: xs}]
    (if {n == 0}
-       nil
+       Nil
        {x :: (take {n - 1} xs)})]
-  [[_ nil]
-   nil])
+  [[_ Nil]
+   Nil])
 
 (defn drop : (∀ [a] {Integer -> (List a) -> (List a)})
   [[n {x :: xs}]
    (if {n == 0}
        {x :: xs}
        (drop {n - 1} xs))]
-  [[_ nil]
-   nil])
+  [[_ Nil]
+   Nil])
 
 (defn filter : (∀ [a] {{a -> Bool} -> (List a) -> (List a)})
   [[f {x :: xs}] (let ([ys (filter f xs)]) (if (f x) {x :: ys} ys))]
-  [[_ nil      ] nil])
+  [[_ Nil      ] Nil])
 
 (defn foldl : (∀ [a b] {{b -> a -> b} -> b -> (List a) -> b})
   [[f a {x :: xs}] (let ([b (f a x)]) {b seq (foldl f b xs)})]
-  [[_ a nil      ] a])
+  [[_ a Nil      ] a])
 
 (def reverse : (∀ [a] {(List a) -> (List a)})
-  (foldl (flip ::) nil))
+  (foldl (flip ::) Nil))
 
 (defn zip-with : (∀ [a b c] {{a -> b -> c} -> (List a) -> (List b) -> (List c)})
   [[f {x :: xs} {y :: ys}] {(f x y) :: (zip-with f xs ys)}]
-  [[_ _         _        ] nil])
+  [[_ _         _        ] Nil])
 
 (def sum : {(List Integer) -> Integer}
   (foldl + 0))
@@ -58,14 +58,14 @@
   [[x] (letrec ([xs {x :: xs}]) xs)])
 
 (defn cycle! : (∀ [a] {(List a) -> (List a)})
-  [[nil] (error! "cycle!: empty list")]
+  [[Nil] (error! "cycle!: empty list")]
   [[xs ] (letrec ([ys {xs ++ ys}]) ys)])
 
 (def or : {(List Bool) -> Bool}
-  (foldr || false))
+  (foldr || False))
 
 (def and : {(List Bool) -> Bool}
-  (foldr && true))
+  (foldr && True))
 
 (defn any? : (∀ [a] {{a -> Bool} -> (List a) -> Bool})
   [[f] {or . (map f)}])
@@ -87,5 +87,5 @@
    (if {y =? x}
        ys
        {y :: (delete-by =? x ys)})]
-  [[_ _ nil]
-   nil])
+  [[_ _ Nil]
+   Nil])

--- a/hackett-lib/hackett/data/maybe.rkt
+++ b/hackett-lib/hackett/data/maybe.rkt
@@ -5,8 +5,8 @@
 (provide (data Maybe) maybe from-maybe)
 
 (defn maybe : (∀ [a b] {b -> {a -> b} -> (Maybe a) -> b})
-  [[_ f (just x)] (f x)]
-  [[v _ nothing ] v])
+  [[_ f (Just x)] (f x)]
+  [[v _ Nothing ] v])
 
 (defn from-maybe : (∀ [a b] {a -> (Maybe a) -> a})
   [[v] (maybe v id)])

--- a/hackett-lib/hackett/main.rkt
+++ b/hackett-lib/hackett/main.rkt
@@ -7,4 +7,6 @@
 
 (module reader syntax/module-reader hackett/main
   #:wrapper1 call-with-hackett-reading-parameterization
-  (require hackett/private/reader))
+  #:module-wrapper module-wrapper-insert-type-require
+  (require hackett/private/reader
+           (submod hackett/private/kernel module-wrapper)))

--- a/hackett-lib/hackett/monad/error.rkt
+++ b/hackett-lib/hackett/monad/error.rkt
@@ -5,45 +5,45 @@
 
 (provide (data ErrorT) run-error-t run-error throw catch)
 
-(data (ErrorT e m a) (error-t (m (Either e a))))
+(data (ErrorT e m a) (ErrorT (m (Either e a))))
 
 (defn run-error-t : (forall [e m a] {(ErrorT e m a) -> (m (Either e a))})
-  [[(error-t x)] x])
+  [[(ErrorT x)] x])
 
 (defn run-error : (forall [e a] {(ErrorT e Identity a) -> (Either e a)})
   [[x] (run-identity (run-error-t x))])
 
 (instance (forall [e] (MonadTrans (ErrorT e)))
-  [lift {error-t . (map right)}])
+  [lift {ErrorT . (map Right)}])
 
 (instance (forall [e m] (Functor m) => (Functor (ErrorT e m)))
-  [map (λ [f (error-t x)] (error-t (map (map f) x)))])
+  [map (λ [f (ErrorT x)] (ErrorT (map (map f) x)))])
 
 (instance (forall [e m] (Monad m) => (Applicative (ErrorT e m)))
-  [pure {error-t . pure . right}]
-  [<*> (λ [(error-t f) (error-t x)]
-         (error-t (do [f* <- f]
-                      (case f*
-                        [(right f**)
-                         {(λ [x*] {f** <$> x*}) <$> x}]
-                        [(left e)
-                         (pure (left e))]))))])
+  [pure {ErrorT . pure . Right}]
+  [<*> (λ [(ErrorT f) (ErrorT x)]
+         (ErrorT (do [f* <- f]
+                     (case f*
+                       [(Right f**)
+                        {(λ [x*] {f** <$> x*}) <$> x}]
+                       [(Left e)
+                        (pure (Left e))]))))])
 
 (instance (forall [e m] (Monad m) => (Monad (ErrorT e m)))
-  [join (λ [(error-t x)]
-          (error-t (do [x* <- x]
-                       (case x*
-                         [(right (error-t x**)) x**]
-                         [(left e) (pure (left e))]))))])
+  [join (λ [(ErrorT x)]
+          (ErrorT (do [x* <- x]
+                      (case x*
+                        [(Right (ErrorT x**)) x**]
+                        [(Left e) (pure (Left e))]))))])
 
 (def throw : (forall [e a m] (Applicative m) => {e -> (ErrorT e m a)})
-  {error-t . pure . left})
+  {ErrorT . pure . Left})
 
 (defn catch : (forall [e e* a m] (Monad m) =>
                       {(ErrorT e m a) -> {e -> (ErrorT e* m a)} -> (ErrorT e* m a)})
-  [[(error-t x) f]
-   (error-t (do [x* <- x]
-                (case x*
-                  [(right x**) (pure (right x**))]
-                  [(left e) (case (f e)
-                              [(error-t y) y])])))])
+  [[(ErrorT x) f]
+   (ErrorT (do [x* <- x]
+               (case x*
+                 [(Right x**) (pure (Right x**))]
+                 [(Left e) (case (f e)
+                             [(ErrorT y) y])])))])

--- a/hackett-lib/hackett/monad/reader.rkt
+++ b/hackett-lib/hackett/monad/reader.rkt
@@ -5,34 +5,34 @@
 
 (provide (data ReaderT) run-reader-t run-reader ask asks local)
 
-(data (ReaderT r m a) (reader-t {r -> (m a)}))
+(data (ReaderT r m a) (ReaderT {r -> (m a)}))
 
 (defn run-reader-t : (forall [r m a] {(ReaderT r m a) -> r -> (m a)})
-  [[(reader-t f)] f])
+  [[(ReaderT f)] f])
 
 (defn run-reader : (forall [r a] {(ReaderT r Identity a) -> r -> a})
   [[x r] (run-identity (run-reader-t x r))])
 
 (instance (forall [r] (MonadTrans (ReaderT r)))
-  [lift {reader-t . const}])
+  [lift {ReaderT . const}])
 
 (instance (forall [r m] (Functor m) => (Functor (ReaderT r m)))
-  [map (λ [f (reader-t x)] (reader-t (λ [r] (map f (x r)))))])
+  [map (λ [f (ReaderT x)] (ReaderT (λ [r] (map f (x r)))))])
 
 (instance (forall [r m] (Applicative m) => (Applicative (ReaderT r m)))
-  [pure {reader-t . const . pure}]
-  [<*> (λ [(reader-t f) (reader-t x)] (reader-t (λ [r] {(f r) <*> (x r)})))])
+  [pure {ReaderT . const . pure}]
+  [<*> (λ [(ReaderT f) (ReaderT x)] (ReaderT (λ [r] {(f r) <*> (x r)})))])
 
 (instance (forall [r m] (Monad m) => (Monad (ReaderT r m)))
-  [join (λ [(reader-t x)]
-          (reader-t (λ [r] (do [x* <- (x r)]
-                               (case x* [(reader-t y) (y r)])))))])
+  [join (λ [(ReaderT x)]
+          (ReaderT (λ [r] (do [x* <- (x r)]
+                               (case x* [(ReaderT y) (y r)])))))])
 
 (def ask : (forall [r m] (Applicative m) => (ReaderT r m r))
-  (reader-t (λ [r] (pure r))))
+  (ReaderT (λ [r] (pure r))))
 
 (defn asks : (forall [r m a] (Applicative m) => {{r -> a} -> (ReaderT r m a)})
-  [[f] (reader-t (λ [r] (pure (f r))))])
+  [[f] (ReaderT (λ [r] (pure (f r))))])
 
 (defn local : (forall [r m a] {{r -> r} -> (ReaderT r m a) -> (ReaderT r m a)})
-  [[f x] (reader-t (λ [r] (run-reader-t x (f r))))])
+  [[f x] (ReaderT (λ [r] (run-reader-t x (f r))))])

--- a/hackett-lib/hackett/prelude.rkt
+++ b/hackett-lib/hackett/prelude.rkt
@@ -28,7 +28,7 @@
          (class Monad) =<< >>= do ap
 
          seq error! undefined!
-         IO main print println
+         (type-out IO) main print println
          + - * quotient! remainder! < > <= >=
          d+ d- d* d/ d< d> d<= d>= integer->double
          string-length string-split

--- a/hackett-lib/hackett/private/adt.rkt
+++ b/hackett-lib/hackett/private/adt.rkt
@@ -402,7 +402,7 @@
    ; calculate the type of the underlying constructor, with arguments, unquantified
    #:with τ_con_unquantified (foldr #{begin #`(@%app -> #,%1 #,%2)}
                                     #'τ_result
-                                    (attribute constructor.arg))
+                                    (map type-namespace-introduce (attribute constructor.arg)))
    ; quantify the type using the type variables in τ, then evaluate the type
    #:with τ_con:type (foldr #{begin #`(∀ #,%1 #,%2)} #'τ_con_unquantified (attribute τ.arg))
    #:with τ_con-expr (preservable-property->expression (attribute τ_con.τ))
@@ -435,12 +435,13 @@
 
 (define-syntax-parser data
   [(_ τ:type-constructor-spec constructor:data-constructor-spec ...)
+   #:with [τ*:type-constructor-spec] (type-namespace-introduce #'τ)
    #`(begin-
        #,(indirect-infix-definition
-          #'(define-syntax- τ.tag (make-type-variable-transformer
-                                   (τ:con #'τ.tag (list #'constructor.tag ...))))
+          #'(define-syntax- τ*.tag (make-type-variable-transformer
+                                    (τ:con #'τ*.tag (list #'constructor.tag ...))))
           (attribute τ.fixity))
-       (define-data-constructor τ constructor) ...)])
+       (define-data-constructor τ* constructor) ...)])
 
 (begin-for-syntax
   (define-syntax-class (case*-clause num-pats)
@@ -565,7 +566,7 @@
 (define-syntax-parser defn
   #:literals [:]
   [(_ id:id
-      {~or {~optional {~seq : t:type}}
+      {~or {~optional {~seq : {~type t:type}}}
            {~optional fixity:fixity-annotation}}
       ...
       clauses:λ*-clauses)

--- a/hackett-lib/hackett/private/base.rkt
+++ b/hackett-lib/hackett/private/base.rkt
@@ -24,7 +24,7 @@
          (rename-out [#%top @%top]
                      [∀ forall])
          @%module-begin @%datum @%app @%superclasses-key @%dictionary-placeholder @%with-dictionary
-         submodule-part type-out only-types-in unmangle-types-in
+         module+ type-out only-types-in unmangle-types-in
          define-primop define-base-type
          -> ∀ => Integer Double String
          : λ1 def let letrec)
@@ -352,7 +352,7 @@
       (for/list ([(name parts) (in-hash all-parts)])
         (let ([parts* (map syntax-local-introduce (reverse parts))])
           (datum->syntax (first parts*)
-                         (list* #'module* name #f parts*)
+                         (list* #'module*- name #f parts*)
                          (first parts*)))))))
 
 (define-syntax-parser @%module-begin
@@ -394,11 +394,14 @@
    #:with [submod-decl ...] (submodule-parts->submodules)
    #'(begin- submod-decl ...)])
 
-(define-syntax-parser submodule-part
+(define-syntax-parser module+
   [(_ name:id body ...)
    #:fail-unless (eq? (syntax-local-context) 'module) "not at module top level"
-   #:do [(for ([body (in-list (attribute body))])
-           (lift-submodule-part! (syntax-e #'name) body))]
+   #:do [(lift-submodule-part!
+          (syntax-e #'name)
+          (datum->syntax this-syntax
+                         (cons #'begin- (attribute body))
+                         this-syntax))]
    #'(begin-)])
 
 (define-syntax-parser begin/value-namespace

--- a/hackett-lib/hackett/private/base.rkt
+++ b/hackett-lib/hackett/private/base.rkt
@@ -8,8 +8,8 @@
                      threading)
          (postfix-in - (combine-in racket/base
                                    racket/promise
-                                   racket/splicing
-                                   syntax/id-table))
+                                   syntax/id-table
+                                   hackett/private/splicing))
          racket/stxparam
          syntax/parse/define
 

--- a/hackett-lib/hackett/private/base.rkt
+++ b/hackett-lib/hackett/private/base.rkt
@@ -1,12 +1,14 @@
 #lang curly-fn racket/base
 
-(require racket/require hackett/private/util/require)
+(require racket/provide racket/require hackett/private/util/require)
 
-(require (for-syntax (multi-in racket [base contract list match syntax])
+(require (for-syntax (multi-in racket [base contract list match provide-transform require-transform
+                                       syntax])
                      syntax/parse/experimental/template
                      threading)
          (postfix-in - (combine-in racket/base
                                    racket/promise
+                                   racket/splicing
                                    syntax/id-table))
          racket/stxparam
          syntax/parse/define
@@ -19,10 +21,10 @@
 (provide (for-syntax (all-from-out hackett/private/typecheck)
                      τs⇔/λ! τ⇔/λ! τ⇔! τ⇐/λ! τ⇐! τ⇒/λ! τ⇒! τ⇒app! τs⇒!)
          #%module-begin #%top
-         (rename-out [#%plain-module-begin @%module-begin]
-                     [#%top @%top]
+         (rename-out [#%top @%top]
                      [∀ forall])
-         @%datum @%app @%superclasses-key @%dictionary-placeholder @%with-dictionary
+         @%module-begin @%datum @%app @%superclasses-key @%dictionary-placeholder @%with-dictionary
+         submodule-part type-out only-types-in unmangle-types-in
          define-primop define-base-type
          -> ∀ => Integer Double String
          : λ1 def let letrec)
@@ -332,6 +334,137 @@
                      constrs)))])
        dict-expr)])
 
+;; ---------------------------------------------------------------------------------------------------
+
+(define-syntax-parameter current-lifted-submodule-parts #f)
+
+(begin-for-syntax
+  (define/contract (lift-submodule-part! submod-name stx)
+    (-> symbol? syntax? void?)
+    (unless (syntax-parameter-value #'current-lifted-submodule-parts)
+      (error 'lift-submodule-part!
+             "not currently transforming in a context that supports lifting submodule parts"))
+    (hash-update! (syntax-parameter-value #'current-lifted-submodule-parts)
+                  submod-name #{cons (syntax-local-introduce stx) %} '()))
+
+  (define (submodule-parts->submodules)
+    (let ([all-parts (syntax-parameter-value #'current-lifted-submodule-parts)])
+      (for/list ([(name parts) (in-hash all-parts)])
+        (let ([parts* (map syntax-local-introduce (reverse parts))])
+          (datum->syntax (first parts*)
+                         (list* #'module* name #f parts*)
+                         (first parts*)))))))
+
+(define-syntax-parser @%module-begin
+  [(_ form ...)
+   #:with [body-form ...] #'((begin/value-namespace form ...)
+                             (lifted-submodules))
+   ; If we expand to code that uses make-syntax-introducer directly, then we’ll end up with a
+   ; different scope for each instantiation of the module. Normally this is okay, but it isn’t when
+   ; dealing with (module* m #f ....) submodules, which ought to inherit the namespace scopes from
+   ; their enclosing modules.
+   ;
+   ; To accommodate this case, we can expand to pieces of syntax, then use
+   ; make-syntax-delta-introducer to ensure that the scopes remain the same across multiple module
+   ; instantiations. Additionally, when we detect we’re inside such a submodule, we don’t want to
+   ; re-parameterize the introducers (since we want to use the ones we inherit from the enclosing
+   ; module).
+   #:with scopeless (datum->syntax #f 'introducer-id)
+   #:with value-scoped ((make-syntax-introducer #t) #'scopeless)
+   #:with type-scoped ((make-syntax-introducer #t) #'scopeless)
+   (if (syntax-parameter-value #'current-value-introducer)
+       #'(#%plain-module-begin
+          (splicing-syntax-parameterize-
+              ([current-lifted-submodule-parts (make-hasheq)])
+            body-form ...))
+       #'(#%plain-module-begin
+          (splicing-let-syntax- ([scopeless #f] [value-scoped #f] [type-scoped #f])
+            (splicing-syntax-parameterize-
+                ([current-value-introducer (make-syntax-delta-introducer
+                                            (quote-syntax value-scoped)
+                                            (quote-syntax scopeless))]
+                 [current-type-introducer (make-syntax-delta-introducer
+                                           (quote-syntax type-scoped)
+                                           (quote-syntax scopeless))]
+                 [current-lifted-submodule-parts (make-hasheq)])
+              body-form ...))))])
+
+(define-syntax-parser lifted-submodules
+  [(_)
+   #:with [submod-decl ...] (submodule-parts->submodules)
+   #'(begin- submod-decl ...)])
+
+(define-syntax-parser submodule-part
+  [(_ name:id body ...)
+   #:fail-unless (eq? (syntax-local-context) 'module) "not at module top level"
+   #:do [(for ([body (in-list (attribute body))])
+           (lift-submodule-part! (syntax-e #'name) body))]
+   #'(begin-)])
+
+(define-syntax-parser begin/value-namespace
+  [(_ form ...)
+   (value-namespace-introduce
+    (syntax/loc this-syntax
+      (begin form ...)))])
+
+(define-syntax-parser begin/type-namespace
+  [(_ form ...)
+   (type-namespace-introduce
+    (syntax/loc this-syntax
+      (begin form ...)))])
+
+(begin-for-syntax
+  (define (mangle-type-name name)
+    (string-append "#%hackett-type:" name))
+
+  (define mangled-type-regexp #rx"^#%hackett-type:(.+)$")
+  (define (unmangle-type-name name)
+    (and~> (regexp-match mangled-type-regexp name) second))
+  (define (unmangle-value-name name)
+    (and (not (regexp-match? mangled-type-regexp name)) name)))
+
+(define-syntax type-out
+  (make-provide-pre-transformer
+   (λ (stx modes)
+     (syntax-parse stx
+       [(_ {~optional {~and #:no-introduce no-introduce?}} provide-spec ...)
+        (pre-expand-export
+         #`(filtered-out mangle-type-name
+                         #,((if (attribute no-introduce?) values type-namespace-introduce)
+                            #'(combine-out provide-spec ...)))
+         modes)]))))
+
+(define-syntax only-types-in
+  (make-require-transformer
+   (syntax-parser
+     [(_ require-spec ...)
+      (expand-import
+       #`(filtered-in (λ (name) (and (regexp-match? mangled-type-regexp name) name))
+                      (combine-in require-spec ...)))])))
+
+(define-syntax unmangle-types-in
+  (make-require-transformer
+   (syntax-parser
+     [(_ {~optional {~and #:no-introduce no-introduce?}} require-spec ...)
+      #:do [(define-values [imports sources] (expand-import #'(combine-in require-spec ...)))]
+      (values (map (match-lambda
+                     [(and i (import local-id src-sym src-mod-path mode req-mode orig-mode orig-stx))
+                      (let* ([local-name (symbol->string (syntax-e local-id))]
+                             [unmangled-type-name (unmangle-type-name local-name)])
+                        (if unmangled-type-name
+                            (let ([unmangled-id (datum->syntax local-id
+                                                               (string->symbol unmangled-type-name)
+                                                               local-id
+                                                               local-id)])
+                              (import (if (attribute no-introduce?) unmangled-id
+                                          (type-namespace-introduce unmangled-id))
+                                      src-sym src-mod-path mode req-mode orig-mode orig-stx))
+                            i))])
+                   imports)
+              sources)])))
+
+;; ---------------------------------------------------------------------------------------------------
+
 (define-syntax-parser @%datum
   [(_ . n:exact-integer)
    (attach-type #'(#%datum . n) (parse-type #'Integer))]
@@ -344,7 +477,7 @@
    (raise-syntax-error #f "literal not supported" #'x)])
 
 (define-syntax-parser :
-  [(_ e t-expr:type)
+  [(_ e {~type t-expr:type})
    (attach-type #`(let-values- ([() (begin- (λ- () t-expr.expansion) (values-))])
                     #,(τ⇐! #'e (attribute t-expr.τ)))
                 (apply-current-subst (attribute t-expr.τ)))])
@@ -381,7 +514,7 @@
 (define-syntax-parser def
   #:literals [:]
   [(_ id:id
-      {~or {~once {~seq : t:type}}
+      {~or {~once {~seq : {~type t:type}}}
            {~optional fixity:fixity-annotation}}
       ...
       e:expr)
@@ -411,7 +544,7 @@
 
 (define-syntax-parser let1
   #:literals [:]
-  [(_ [id:id {~optional {~seq colon:: t-ann:type}} val:expr] body:expr)
+  [(_ [id:id {~optional {~seq colon:: {~type t-ann:type}}} val:expr] body:expr)
    #:do [(define-values [val- t_val] (τ⇔! #'val (attribute t-ann.τ)))
          (match-define-values [(list id-) body- t_body]
            (τ⇔/λ! #'body (get-expected this-syntax) (list (cons #'id t_val))))]
@@ -424,7 +557,7 @@
 
 (define-syntax-parser let
   #:literals [:]
-  [(_ ([id:id {~optional {~seq colon:: t-ann:type}} val:expr] ...+) body:expr)
+  [(_ ([id:id {~optional {~seq colon:: {~type t-ann:type}}} val:expr] ...+) body:expr)
    (syntax-parse this-syntax
      [(_ (binding-pair) body)
       (syntax/loc this-syntax
@@ -437,7 +570,7 @@
 
 (define-syntax-parser letrec
   #:literals [:]
-  [(_ ([id:id {~optional {~seq colon:: t-ann:type}} val:expr] ...+) body:expr)
+  [(_ ([id:id {~optional {~seq colon:: {~type t-ann:type}}} val:expr] ...+) body:expr)
    ; First, infer or check the type of each binding. Use τ⇐!\λ to check the type if a type annotation
    ; is provided. Otherwise, use τ⇒!/λ to infer it, and synthesize a fresh type variable for id’s
    ; type during inference. If a type is successfully inferred, unify it with the fresh type variable

--- a/hackett-lib/hackett/private/kernel.rkt
+++ b/hackett-lib/hackett/private/kernel.rkt
@@ -15,15 +15,43 @@
                      [@%top #%top]
                      [@%datum #%datum]
                      [@%app #%app]
-                     [λ lambda]
-                     [∀ forall])
-         require combine-in except-in only-in prefix-in rename-in
-         provide combine-out except-out prefix-out rename-out
-         : def λ let letrec ∀ -> => Integer Double String)
+                     [@%require require]
+                     [λ lambda])
+         #%require/only-types combine-in except-in only-in prefix-in rename-in
+         provide combine-out except-out prefix-out rename-out type-out
+         : def λ let letrec
+         (type-out #:no-introduce ∀ -> => Integer Double String
+                   (rename-out [∀ forall])))
+
+(module module-wrapper racket/base
+  (require syntax/parse syntax/strip-context)
+  (provide module-wrapper-insert-type-require)
+  (define (module-wrapper-insert-type-require read-module)
+    (syntax-parse (read-module)
+      [(module mod-name mod-path
+         (#%module-begin form ...))
+       (datum->syntax this-syntax
+                      (syntax-e (strip-context
+                                 #'(module mod-name mod-path
+                                     (#%module-begin
+                                      (#%require/only-types mod-path)
+                                      form ...))))
+                      this-syntax
+                      this-syntax)])))
 
 (module reader syntax/module-reader hackett/private/kernel
   #:wrapper1 call-with-hackett-reading-parameterization
-  (require hackett/private/reader))
+  #:module-wrapper module-wrapper-insert-type-require
+  (require hackett/private/reader
+           (submod ".." module-wrapper)))
+
+(define-syntax-parser @%require
+  [(_ require-spec ...)
+   #'(require (unmangle-types-in require-spec) ...)])
+
+(define-syntax-parser #%require/only-types
+  [(_ require-spec ...)
+   #'(@%require (only-types-in require-spec ...))])
 
 (define-syntax-parser λ
   [(_ [x:id] e:expr)

--- a/hackett-lib/hackett/private/kernel.rkt
+++ b/hackett-lib/hackett/private/kernel.rkt
@@ -9,7 +9,9 @@
          (rename-in hackett/private/base
                     [@%app @%app1]
                     [∀ ∀1]
-                    [=> =>1]))
+                    [=> =>1])
+         (only-in hackett/private/module-plus module+)
+         hackett/private/type-reqprov)
 
 (provide (rename-out [@%module-begin #%module-begin]
                      [@%top #%top]

--- a/hackett-lib/hackett/private/kernel.rkt
+++ b/hackett-lib/hackett/private/kernel.rkt
@@ -18,7 +18,7 @@
                      [@%require require]
                      [λ lambda])
          #%require/only-types combine-in except-in only-in prefix-in rename-in
-         provide combine-out except-out prefix-out rename-out type-out
+         provide combine-out except-out prefix-out rename-out type-out module+
          : def λ let letrec
          (type-out #:no-introduce ∀ -> => Integer Double String
                    (rename-out [∀ forall])))

--- a/hackett-lib/hackett/private/module-plus.rkt
+++ b/hackett-lib/hackett/private/module-plus.rkt
@@ -1,0 +1,52 @@
+#lang curly-fn racket/base
+
+; This module contains an alternative implementation of ‘module+’ from racket/base that avoids
+; ‘syntax-local-lift-module-end-declaration’, which does not interact well with Hackett’s namespacing
+; system (since declarations are lifted outside the scope of the syntax parameterization that controls
+; which scope introducers are currently in effect).
+;
+; This implementation simply provides a form, ‘with-module+-lift-target’, that can be used in
+; Hackett’s ‘#%module-begin’ to essentially capture lifted module declarations.
+
+(require (for-syntax racket/base
+                     racket/list)
+         racket/splicing
+         racket/stxparam
+         syntax/parse/define)
+
+(provide module+ with-module+-lift-target)
+
+(define-syntax-parameter current-lifted-submodule-parts #f)
+
+(begin-for-syntax
+  (define (lift-submodule-part! submod-name stx)
+    (hash-update! (syntax-parameter-value #'current-lifted-submodule-parts)
+                  submod-name #{cons (syntax-local-introduce stx) %} '()))
+
+  (define (submodule-parts->submodules all-parts)
+    (for/list ([(name parts) (in-hash all-parts)])
+      (let ([parts* (map syntax-local-introduce (reverse parts))])
+        (datum->syntax (first parts*)
+                       (list* #'module* name #f parts*)
+                       (first parts*))))))
+
+(define-simple-macro (module+ name:id body ...)
+  #:fail-unless (eq? (syntax-local-context) 'module) "not at module top level"
+  #:fail-unless (syntax-parameter-value #'current-lifted-submodule-parts)
+                "not in a context that allows partial module declarations"
+  #:do [(lift-submodule-part!
+         (syntax-e #'name)
+         (datum->syntax this-syntax
+                        (cons #'begin (attribute body))
+                        this-syntax))]
+  (begin))
+
+(define-simple-macro (with-module+-lift-target form ...)
+  (splicing-syntax-parameterize ([current-lifted-submodule-parts (make-hasheq)])
+    form ...
+    (lifted-submodules)))
+
+(define-simple-macro (lifted-submodules)
+  #:with [submod-decl ...] (submodule-parts->submodules
+                            (syntax-parameter-value #'current-lifted-submodule-parts))
+  (begin submod-decl ...))

--- a/hackett-lib/hackett/private/prim.rkt
+++ b/hackett-lib/hackett/private/prim.rkt
@@ -5,6 +5,7 @@
          (for-syntax racket/base)
          (postfix-in - (combine-in racket/base racket/promise))
          syntax/parse/define
+         (only-in hackett/private/base submodule-part)
          (only-in hackett/private/kernel [#%app @%app])
 
          hackett/private/prim/base
@@ -19,5 +20,5 @@
 
 (define-syntax-parser main
   [(_ e:expr)
-   #'(module+ main
+   #'(submodule-part main
        (void- (force- (@%app unsafe-run-io! e))))])

--- a/hackett-lib/hackett/private/prim.rkt
+++ b/hackett-lib/hackett/private/prim.rkt
@@ -5,7 +5,7 @@
          (for-syntax racket/base)
          (postfix-in - (combine-in racket/base racket/promise))
          syntax/parse/define
-         (only-in hackett/private/base submodule-part)
+         (only-in hackett/private/base module+)
          (only-in hackett/private/kernel [#%app @%app])
 
          hackett/private/prim/base
@@ -20,5 +20,6 @@
 
 (define-syntax-parser main
   [(_ e:expr)
-   #'(submodule-part main
-       (void- (force- (@%app unsafe-run-io! e))))])
+   (datum->syntax this-syntax
+                  (list #'module+ #'main #'(void- (force- (@%app unsafe-run-io! e))))
+                  this-syntax)])

--- a/hackett-lib/hackett/private/prim.rkt
+++ b/hackett-lib/hackett/private/prim.rkt
@@ -5,8 +5,7 @@
          (for-syntax racket/base)
          (postfix-in - (combine-in racket/base racket/promise))
          syntax/parse/define
-         (only-in hackett/private/base module+)
-         (only-in hackett/private/kernel [#%app @%app])
+         (only-in hackett/private/kernel module+ [#%app @%app])
 
          hackett/private/prim/base
          hackett/private/prim/op

--- a/hackett-lib/hackett/private/prim/base.rkt
+++ b/hackett-lib/hackett/private/prim/base.rkt
@@ -27,33 +27,33 @@
 ;; basic operations
 
 (defn not : {Bool -> Bool}
-  [[true ] false]
-  [[false] true])
+  [[True ] False]
+  [[False] True])
 
 (defn || : {Bool -> Bool -> Bool} #:fixity right
-  [[true  _] true]
-  [[false y] y])
+  [[True  _] True]
+  [[False y] y])
 
 (defn && : {Bool -> Bool -> Bool} #:fixity right
-  [[true  y] y]
-  [[false _] false])
+  [[True  y] y]
+  [[False _] False])
 
 (defn if : (∀ [a] {Bool -> a -> a -> a})
-  [[true  x _] x]
-  [[false _ y] y])
+  [[True  x _] x]
+  [[False _ y] y])
 
 (defn fst : (∀ [a b] {(Tuple a b) -> a})
-  [[(tuple x _)] x])
+  [[(Tuple x _)] x])
 
 (defn snd : (∀ [a b] {(Tuple a b) -> b})
-  [[(tuple _ x)] x])
+  [[(Tuple _ x)] x])
 
 (defn foldr : (∀ [a b] {{a -> b -> b} -> b -> (List a) -> b})
   [[f a {x :: xs}] (f x (foldr f a xs))]
-  [[_ a nil      ] a])
+  [[_ a Nil      ] a])
 
 (defn unsafe-run-io! : (∀ [a] {(IO a) -> a})
-  [[(io f)] (snd (f real-world))])
+  [[(IO f)] (snd (f Real-World))])
 
 ;; ---------------------------------------------------------------------------------------------------
 ;; function combinators
@@ -83,11 +83,11 @@
   [show : {a -> String}])
 
 (instance (Show Unit)
-  [show (λ [unit] "unit")])
+  [show (λ [Unit] "Unit")])
 
 (instance (Show Bool)
-  [show (λ* [[true ] "true"]
-            [[false] "false"])])
+  [show (λ* [[True ] "True"]
+            [[False] "False"])])
 
 (instance (Show Integer)
   [show show/Integer])
@@ -99,20 +99,20 @@
   [show (λ [str] {"\"" ++ str ++ "\""})])
 
 (instance (∀ [a] (Show a) => (Show (Maybe a)))
-  [show (λ* [[(just x)] {"(just " ++ (show x) ++ ")"}]
-            [[nothing ] "nothing"])])
+  [show (λ* [[(Just x)] {"(Just " ++ (show x) ++ ")"}]
+            [[Nothing ] "Nothing"])])
 
 (instance (∀ [a b] (Show a) (Show b) => (Show (Either a b)))
-  [show (λ* [[(left x)] {"(left " ++ (show x) ++ ")"}]
-            [[(right x)] {"(right " ++ (show x) ++ ")"}])])
+  [show (λ* [[(Left x)] {"(Left " ++ (show x) ++ ")"}]
+            [[(Right x)] {"(Right " ++ (show x) ++ ")"}])])
 
 (instance (∀ [a b] (Show a) (Show b) => (Show (Tuple a b)))
-  [show (λ [(tuple a b)] {"(tuple " ++ (show a) ++ " " ++ (show b) ++ ")"})])
+  [show (λ [(Tuple a b)] {"(Tuple " ++ (show a) ++ " " ++ (show b) ++ ")"})])
 
 (instance (∀ [a] (Show a) => (Show (List a)))
-  [show (λ* [[nil] "nil"]
+  [show (λ* [[Nil] "Nil"]
             [[xs] (let ([strs (map {(λ [x] {x ++ " :: "}) . show} xs)])
-                    {"{" ++ (concat strs) ++ "nil}"})])])
+                    {"{" ++ (concat strs) ++ "Nil}"})])])
 
 ;; ---------------------------------------------------------------------------------------------------
 ;; Eq
@@ -121,11 +121,11 @@
   [== : {a -> a -> Bool}])
 
 (instance (Eq Unit)
-  [== (λ [unit unit] true)])
+  [== (λ [Unit Unit] True)])
 
 (instance (Eq Bool)
-  [== (λ* [[true  y] y]
-          [[false y] (not y)])])
+  [== (λ* [[True  y] y]
+          [[False y] (not y)])])
 
 (instance (Eq Integer)
   [== equal?/Integer])
@@ -137,22 +137,22 @@
   [== equal?/String])
 
 (instance (∀ [a] (Eq a) => (Eq (Maybe a)))
-  [== (λ* [[(just a) (just b)] {a == b}]
-          [[nothing  nothing ] true]
-          [[_        _       ] false])])
+  [== (λ* [[(Just a) (Just b)] {a == b}]
+          [[Nothing  Nothing ] True]
+          [[_        _       ] False])])
 
 (instance (∀ [a b] (Eq a) (Eq b) => (Eq (Either a b)))
-  [== (λ* [[(right a) (right b)] {a == b}]
-          [[(left  a) (left  b)] {a == b}]
-          [[_         _        ] false])])
+  [== (λ* [[(Right a) (Right b)] {a == b}]
+          [[(Left  a) (Left  b)] {a == b}]
+          [[_         _        ] False])])
 
 (instance (∀ [a b] (Eq a) (Eq b) => (Eq (Tuple a b)))
-  [== (λ [(tuple a b) (tuple c d)] {{a == c} && {b == d}})])
+  [== (λ [(Tuple a b) (Tuple c d)] {{a == c} && {b == d}})])
 
 (instance (∀ [a] (Eq a) => (Eq (List a)))
   [== (λ* [[{x :: xs} {y :: ys}] {{x == y} && {xs == ys}}]
-          [[nil       nil      ] true]
-          [[_         _        ] false])])
+          [[Nil       Nil      ] True]
+          [[_         _        ] False])])
 
 ;; ---------------------------------------------------------------------------------------------------
 ;; Semigroup / Monoid
@@ -165,14 +165,14 @@
   [++ append/String])
 
 (instance (∀ [a] (Semigroup a) => (Semigroup (Maybe a)))
-  [++ (λ* [[(just x) (just y)] (just {x ++ y})]
-          [[(just x) nothing ] (just x)]
-          [[nothing  (just y)] (just y)]
-          [[nothing  nothing ] nothing])])
+  [++ (λ* [[(Just x) (Just y)] (Just {x ++ y})]
+          [[(Just x) Nothing ] (Just x)]
+          [[Nothing  (Just y)] (Just y)]
+          [[Nothing  Nothing ] Nothing])])
 
 (instance (∀ [a] (Semigroup (List a)))
   [++ (λ* [[{z :: zs} ys] {z :: {zs ++ ys}}]
-          [[nil       ys] ys])])
+          [[Nil       ys] ys])])
 
 (instance (∀ [a b] (Semigroup b) => (Semigroup {a -> b}))
   [++ (λ [f g x] {(f x) ++ (g x)})])
@@ -184,10 +184,10 @@
   [mempty ""])
 
 (instance (∀ [a] (Semigroup a) => (Monoid (Maybe a)))
-  [mempty nothing])
+  [mempty Nothing])
 
 (instance (∀ [a] (Monoid (List a)))
-  [mempty nil])
+  [mempty Nil])
 
 (instance (∀ [a b] (Monoid b) => (Monoid {a -> b}))
   [mempty (λ [_] mempty)])
@@ -211,25 +211,25 @@
   (flip <$))
 
 (def ignore : (∀ [f a] (Functor f) => {(f a) -> (f Unit)})
-  (map (const unit)))
+  (map (const Unit)))
 
 (instance (Functor Maybe)
-  [map (λ* [[f (just x)] (just (f x))]
-           [[_ nothing ] nothing])])
+  [map (λ* [[f (Just x)] (Just (f x))]
+           [[_ Nothing ] Nothing])])
 
 (instance (∀ [e] (Functor (Either e)))
-  [map (λ* [[f (right x)] (right (f x))]
-           [[_ (left  x)] (left  x)])])
+  [map (λ* [[f (Right x)] (Right (f x))]
+           [[_ (Left  x)] (Left  x)])])
 
 (instance (Functor List)
   [map (λ* [[f {y :: ys}] {(f y) :: (map f ys)}]
-           [[_ nil      ] nil])])
+           [[_ Nil      ] Nil])])
 
 (instance (Functor IO)
-  [map (λ [f (io mx)]
-         (io (λ [rw]
+  [map (λ [f (IO mx)]
+         (IO (λ [rw]
                (case (mx rw)
-                 [(tuple rw* a) (tuple rw* (f a))]))))])
+                 [(Tuple rw* a) (Tuple rw* (f a))]))))])
 
 ;; ---------------------------------------------------------------------------------------------------
 ;; Applicative
@@ -240,27 +240,27 @@
 
 (defn sequence : (∀ [f a] (Applicative f) => {(List (f a)) -> (f (List a))})
   [[{y :: ys}] {:: map y <*> (sequence ys)}]
-  [[nil      ] (pure nil)])
+  [[Nil      ] (pure Nil)])
 
 (defn traverse : (∀ [f a b] (Applicative f) => {{a -> (f b)} -> (List a) -> (f (List b))})
   [[f xs] (sequence (map f xs))])
 
 (instance (Applicative Maybe)
-  [pure just]
-  [<*> (λ* [[(just f) x] (map f x)]
-           [[nothing  _] nothing])])
+  [pure Just]
+  [<*> (λ* [[(Just f) x] (map f x)]
+           [[Nothing  _] Nothing])])
 
 (instance (∀ [e] (Applicative (Either e)))
-  [pure right]
-  [<*> (λ* [[(right f) x] (map f x)]
-           [[(left  x) _] (left x)])])
+  [pure Right]
+  [<*> (λ* [[(Right f) x] (map f x)]
+           [[(Left  x) _] (Left x)])])
 
 (instance (Applicative List)
-  [pure (λ [x] {x :: nil})]
+  [pure (λ [x] {x :: Nil})]
   [<*> ap])
 
 (instance (Applicative IO)
-  [pure (λ [x] (io (λ [rw] (tuple rw x))))]
+  [pure (λ [x] (IO (λ [rw] (Tuple rw x))))]
   [<*> ap])
 
 ;; ---------------------------------------------------------------------------------------------------
@@ -292,24 +292,24 @@
                (pure (f x)))])
 
 (instance (Monad Maybe)
-  [join (λ* [[(just (just x))] (just x)]
-            [[_              ] nothing])])
+  [join (λ* [[(Just (Just x))] (Just x)]
+            [[_              ] Nothing])])
 
 (instance (∀ [e] (Monad (Either e)))
-  [join (λ* [[(right (right x))] (right x)]
-            [[(right (left  x))] (left  x)]
-            [[(left  x)        ] (left  x)])])
+  [join (λ* [[(Right (Right x))] (Right x)]
+            [[(Right (Left  x))] (Left  x)]
+            [[(Left  x)        ] (Left  x)])])
 
 (instance (Monad List)
   [join (λ* [[{{z :: zs} :: yss}] {z :: (join {zs :: yss})}]
-            [[{nil       :: yss}] (join yss)]
-            [[nil               ] nil])])
+            [[{Nil       :: yss}] (join yss)]
+            [[Nil               ] Nil])])
 
 (instance (Monad IO)
-  [join (λ [(io outer)]
-          (io (λ [rw]
+  [join (λ [(IO outer)]
+          (IO (λ [rw]
                 (case (outer rw)
-                  [(tuple rw* m-inner)
+                  [(Tuple rw* m-inner)
                    (case m-inner
-                     [(io inner)
+                     [(IO inner)
                       (inner rw*)])]))))])

--- a/hackett-lib/hackett/private/prim/op.rkt
+++ b/hackett-lib/hackett/private/prim/op.rkt
@@ -7,7 +7,7 @@
                                    racket/promise
                                    racket/string))
          (except-in hackett/private/base)
-         hackett/private/prim/type
+         (unmangle-types-in #:no-introduce hackett/private/prim/type)
          hackett/private/prim/type-provide)
 
 ;; ---------------------------------------------------------------------------------------------------

--- a/hackett-lib/hackett/private/prim/op.rkt
+++ b/hackett-lib/hackett/private/prim/op.rkt
@@ -6,8 +6,11 @@
                                    racket/match
                                    racket/promise
                                    racket/string))
-         (except-in hackett/private/base)
-         (unmangle-types-in #:no-introduce hackett/private/prim/type)
+         hackett/private/base
+         (unmangle-types-in #:no-introduce (only-types-in hackett/private/prim/type))
+         (only-in hackett/private/prim/type
+                  True False :: Nil
+                  [Unit MkUnit] [Tuple MkTuple] [IO MkIO])
          hackett/private/prim/type-provide)
 
 ;; ---------------------------------------------------------------------------------------------------
@@ -44,12 +47,12 @@
           [error! : (∀ a {String -> a})]))
 
 (define (boolean->Bool x)
-  (if- x true false))
+  (if- x True False))
 
 (define list->List
   (match-lambda-
     [(cons x xs) ((:: x) (list->List xs))]
-    ['()         nil]))
+    ['()         Nil]))
 
 ;; ---------------------------------------------------------------------------------------------------
 ;; Integer
@@ -98,8 +101,8 @@
 (define ((seq x) y) (force- x) y)
 
 (define (print str)
-  (io (λ- (rw)
-        (display- (force- str))
-        ((tuple rw) unit))))
+  (MkIO (λ- (rw)
+          (display- (force- str))
+          ((MkTuple rw) MkUnit))))
 
 (define (error! str) (error- (force- str)))

--- a/hackett-lib/hackett/private/prim/op.rkt
+++ b/hackett-lib/hackett/private/prim/op.rkt
@@ -1,11 +1,14 @@
 #lang racket/base
 
-(require hackett/private/util/require
+(require hackett/private/type-reqprov
+         hackett/private/util/require
+
          (postfix-in - (combine-in racket/base
                                    racket/flonum
                                    racket/match
                                    racket/promise
                                    racket/string))
+
          hackett/private/base
          (unmangle-types-in #:no-introduce (only-types-in hackett/private/prim/type))
          (only-in hackett/private/prim/type

--- a/hackett-lib/hackett/private/prim/type.rkt
+++ b/hackett-lib/hackett/private/prim/type.rkt
@@ -6,14 +6,14 @@
 (provide (data Unit) (data Bool) (data Tuple) (data Maybe) (data Either) (data List)
          (data IO) (data Real-World))
 
-(data Unit unit)
-(data Bool true false)
-(data (Tuple a b) (tuple a b))
-(data (Maybe a) (just a) nothing)
-(data (Either a b) (left a) (right b))
+(data Unit Unit)
+(data Bool True False)
+(data (Tuple a b) (Tuple a b))
+(data (Maybe a) (Just a) Nothing)
+(data (Either a b) (Left a) (Right b))
 (data (List a)
   {a :: (List a)} #:fixity right
-  nil)
+  Nil)
 
-(data Real-World real-world)
-(data (IO a) (io (-> Real-World (Tuple Real-World a))))
+(data Real-World Real-World)
+(data (IO a) (IO (-> Real-World (Tuple Real-World a))))

--- a/hackett-lib/hackett/private/provide.rkt
+++ b/hackett-lib/hackett/private/provide.rkt
@@ -16,38 +16,54 @@
   (define (make-renaming-transformer id-stx)
     (syntax-parser
       [_:id id-stx]
-      [(_:id . args) #`(#,id-stx . args)])))
+      [(_:id . args) (quasisyntax/loc this-syntax (#,id-stx . args))])))
 
 (begin-for-syntax
   (struct data-transformer ()
     #:property prop:procedure
     (let ([transformer (make-renaming-transformer #'define-data)])
       (λ (_ stx) (transformer stx)))
+    #:property prop:provide-pre-transformer
+    (λ (s)
+      (λ (stx modes)
+        (syntax-parse stx
+          [(data type-id:id)
+           (quasisyntax/loc this-syntax
+             (data #,(pre-expand-export #'(type-out type-id) modes)
+                   #,(type-namespace-introduce #'type-id)))])))
     #:property prop:provide-transformer
     (λ (s)
       (λ (stx modes)
         (syntax-parse stx
-          [(_ {~and _:id type-id:type})
+          [(_ type-out-spec {~and _:id type-id:type})
            #:do [(define t (attribute type-id.τ))]
            #:fail-when (and (not (τ:con? t)) #'type-id)
                        "not defined as a datatype"
            #:fail-when (and (not (τ:con-constructors t)) #'type-id)
                        "type does not have visible constructors"
            #:with [ctor-tag ...] (τ:con-constructors t)
-           (expand-export #'(combine-out type-id ctor-tag ...) modes)]))))
+           (expand-export #'(combine-out type-out-spec ctor-tag ...) modes)]))))
 
   (struct class-transformer ()
     #:property prop:procedure
     (let ([transformer (make-renaming-transformer #'define-class)])
       (λ (_ stx) (transformer stx)))
+    #:property prop:provide-pre-transformer
+    (λ (s)
+      (λ (stx modes)
+        (syntax-parse stx
+          [(class class-id:id)
+           (quasisyntax/loc this-syntax
+             (class #,(pre-expand-export #'(type-out class-id) modes)
+                    #,(type-namespace-introduce #'class-id)))])))
     #:property prop:provide-transformer
     (λ (_)
       (λ (stx modes)
         (syntax-parse stx
-          [(_ class-id:class-id)
+          [(_ type-out-spec class-id:class-id)
            #:do [(define class (attribute class-id.local-value))]
            #:with [method-id ...] (free-id-table-keys (class:info-method-table class))
-           (expand-export #'(combine-out class-id method-id ...) modes)])))))
+           (expand-export #'(combine-out type-out-spec method-id ...) modes)])))))
 
 (define-syntax data (data-transformer))
 (define-syntax class (class-transformer))

--- a/hackett-lib/hackett/private/provide.rkt
+++ b/hackett-lib/hackett/private/provide.rkt
@@ -3,12 +3,12 @@
 (require (for-syntax racket/base
                      racket/provide-transform
                      syntax/id-table)
-         racket/splicing
          syntax/parse/define
 
          hackett/private/base
          (rename-in hackett/private/class [class define-class])
-         (rename-in hackett/private/adt [data define-data]))
+         (rename-in hackett/private/adt [data define-data])
+         hackett/private/splicing)
 
 (provide data class)
 

--- a/hackett-lib/hackett/private/provide.rkt
+++ b/hackett-lib/hackett/private/provide.rkt
@@ -6,9 +6,9 @@
          syntax/parse/define
 
          hackett/private/base
+         hackett/private/type-reqprov
          (rename-in hackett/private/class [class define-class])
-         (rename-in hackett/private/adt [data define-data])
-         hackett/private/splicing)
+         (rename-in hackett/private/adt [data define-data]))
 
 (provide data class)
 

--- a/hackett-lib/hackett/private/splicing.rkt
+++ b/hackett-lib/hackett/private/splicing.rkt
@@ -1,0 +1,225 @@
+; The contents of this module include a copy of the implementation of ‘splicing-syntax-parameterize’
+; from racket/splicing. Racket v6.11.0.1 or newer comes with this implementation, but this version is
+; included for compatibility with older versions of Racket.
+;
+; The contents of this module are dual-licensed under the compatible ISC and MIT licenses, the former
+; being the license of the entire Hackett project, the latter the license of the Racket distribution.
+; The full text of the original license is reproduced below:
+;
+; Copyright 2017 PLT Design
+;
+; Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+; associated documentation files (the "Software"), to deal in the Software without restriction,
+; including without limitation the rights to use, copy, modify, merge, publish, distribute,
+; sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+; furnished to do so, subject to the following conditions:
+;
+; The above copyright notice and this permission notice shall be included in all copies or substantial
+; portions of the Software.
+;
+; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+; NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+; OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#lang racket/base
+
+(require (for-syntax racket/base) racket/splicing hackett/private/util/cond-expand)
+(provide (all-from-out racket/splicing))
+
+(cond-expand
+ [(version<? (version) "6.11.0.2")
+  (require (for-syntax syntax/kerncase
+                       racket/syntax
+                       racket/private/stxparamkey)
+           (for-meta 2  ; for wrap-et-param
+                     racket/base
+                     syntax/kerncase)
+           racket/private/stxparam)
+
+  (provide splicing-syntax-parameterize)
+
+  (module syntax/loc/props racket/base
+    (require (for-syntax racket/base))
+    (provide syntax/loc/props quasisyntax/loc/props)
+
+    (define-syntaxes [syntax/loc/props quasisyntax/loc/props]
+      (let ()
+        (define (mk-syntax/loc/props syntax-id)
+          (λ (stx)
+            (syntax-case stx ()
+              [(_ src-expr template)
+               #`(let ([src src-expr])
+                   (datum->syntax (quote-syntax #,stx) (syntax-e (#,syntax-id template)) src src))])))
+        (values (mk-syntax/loc/props #'syntax)
+                (mk-syntax/loc/props #'quasisyntax)))))
+
+  (require (for-syntax 'syntax/loc/props)
+           (for-meta 2 'syntax/loc/props))
+
+  ;; ----------------------------------------
+
+  (define-syntax (splicing-syntax-parameterize stx)
+    (if (eq? 'expression (syntax-local-context))
+        ;; Splicing is no help in an expression context:
+        (do-syntax-parameterize stx #'let-syntaxes #f #f)
+        ;; Let `syntax-parameterize' check syntax, then continue
+        (do-syntax-parameterize stx #'ssp-let-syntaxes #t #t)))
+
+  (define-syntax (ssp-let-syntaxes stx)
+    (syntax-case stx ()
+      [(_ ([(id) rhs] ...) (orig-id ...) body ...)
+       (with-syntax ([(splicing-temp ...) (generate-temporaries #'(id ...))])
+         #'(begin
+             ;; Evaluate each RHS only once:
+             (define-syntax splicing-temp rhs) ...
+             ;; Partially expand `body' to push down `let-syntax':
+             (expand-ssp-body (id ...) (splicing-temp ...) (orig-id ...) body)
+             ...))]))
+
+  (define-syntax (expand-ssp-body stx)
+    (syntax-case stx ()
+      [(_ (sp-id ...) (temp-id ...) (orig-id ...) body)
+       (let ([ctx (syntax-local-make-definition-context #f #f)])
+         (for ([sp-id (in-list (syntax->list #'(sp-id ...)))]
+               [temp-id (in-list (syntax->list #'(temp-id ...)))])
+           (syntax-local-bind-syntaxes (list sp-id)
+                                       #`(syntax-local-value (quote-syntax #,temp-id))
+                                       ctx))
+         (let ([body (local-expand #'(force-expand body)
+                                   (syntax-local-context)
+                                   null ;; `force-expand' actually determines stopping places
+                                   ctx)])
+           (let ([body
+                  ;; Extract expanded body out of `body':
+                  (syntax-case body (quote)
+                    [(quote body) #'body])])
+             (syntax-case body ( begin
+                                  define-values
+                                  define-syntaxes
+                                  begin-for-syntax
+                                  module
+                                  module*
+                                  #%require
+                                  #%provide
+                                  #%declare )
+               [(begin expr ...)
+                (syntax/loc/props body
+                  (begin (expand-ssp-body (sp-id ...) (temp-id ...) (orig-id ...) expr) ...))]
+               [(define-values (id ...) rhs)
+                (syntax/loc/props body
+                  (define-values (id ...)
+                    (letrec-syntaxes ([(sp-id) (syntax-local-value (quote-syntax temp-id))] ...)
+                                     rhs)))]
+               [(define-syntaxes ids rhs)
+                (syntax/loc/props body
+                  (define-syntaxes ids (wrap-param-et rhs (orig-id ...) (temp-id ...))))]
+               [(begin-for-syntax e ...)
+                (syntax/loc/props body
+                  (begin-for-syntax (wrap-param-et e (orig-id ...) (temp-id ...)) ...))]
+               [(module . _) body]
+               [(module* name #f form ...)
+                (datum->syntax body
+                               (list #'module* #'name #f
+                                     #`(expand-ssp-module-begin
+                                        (sp-id ...) (temp-id ...) (orig-id ...)
+                                        #,body name form ...))
+                               body)]
+               [(module* . _) body]
+               [(#%require . _) body]
+               [(#%provide . _) body]
+               [(#%declare . _) body]
+               [expr (syntax/loc body
+                       (letrec-syntaxes ([(sp-id) (syntax-local-value (quote-syntax temp-id))] ...)
+                                        expr))]))))]))
+
+  (define-syntax (expand-ssp-module-begin stx)
+    (syntax-case stx ()
+      [(_ (sp-id ...) (temp-id ...) (orig-id ...) mod-form mod-name-id body-form ...)
+       (unless (eq? (syntax-local-context) 'module-begin)
+         (raise-syntax-error #f "only allowed in module-begin context" stx))
+       (let ([ctx (syntax-local-make-definition-context #f #f)])
+         (for ([sp-id (in-list (syntax->list #'(sp-id ...)))]
+               [temp-id (in-list (syntax->list #'(temp-id ...)))])
+           (syntax-local-bind-syntaxes (list sp-id)
+                                       #`(syntax-local-value (quote-syntax #,temp-id))
+                                       ctx))
+         (let* ([forms (syntax->list #'(body-form ...))]
+                ; emulate how the macroexpander expands module bodies and introduces #%module-begin
+                [body (if (= (length forms) 1)
+                          (let ([body (local-expand (car forms) 'module-begin #f ctx)])
+                            (syntax-case body (#%plain-module-begin)
+                              [(#%plain-module-begin . _) body]
+                              [_ (datum->syntax #'mod-form (list '#%module-begin body) #'mod-form)]))
+                          (datum->syntax #'mod-form (list* '#%module-begin forms) #'mod-form))]
+                [body (syntax-property body 'enclosing-module-name (syntax-e #'mod-name-id))]
+                [body (local-expand body 'module-begin #f ctx)])
+           (syntax-case body (#%plain-module-begin)
+             [(#%plain-module-begin form ...)
+              (syntax/loc/props body
+                (#%plain-module-begin
+                 (expand-ssp-body (sp-id ...) (temp-id ...) (orig-id ...) form) ...))]
+             [_ (raise-syntax-error
+                 #f "expansion of #%module-begin is not a #%plain-module-begin form" body)])))]))
+
+  (define-syntax (force-expand stx)
+    (syntax-case stx ()
+      [(_ stx)
+       ;; Expand `stx' to reveal type of form, and then preserve it via
+       ;; `quote':
+       (syntax-property
+        #`(quote #,(local-expand #'stx
+                                 'module
+                                 (kernel-form-identifier-list)
+                                 #f))
+        'certify-mode
+        'transparent)]))
+
+  (define-for-syntax (parameter-of id)
+    (let ([sp (syntax-parameter-local-value id)])
+      (syntax-parameter-target-parameter
+       (syntax-parameter-target sp))))
+
+  (begin-for-syntax
+    (define-syntax (wrap-param-et stx)
+      (syntax-case stx ()
+        [(_ e (orig-id ...) (temp-id ...))
+         (let ([as-expression
+                (lambda ()
+                  #'(parameterize ([(parameter-of (quote-syntax orig-id)) 
+                                    (quote-syntax temp-id)]
+                                   ...)
+                      e))])
+           (if (eq? (syntax-local-context) 'expression)
+               (as-expression)
+               (let ([e (local-expand #'e
+                                      (syntax-local-context)
+                                      (kernel-form-identifier-list)
+                                      #f)])
+                 (syntax-case e (begin
+                                  define-syntaxes define-values
+                                  begin-for-syntax
+                                  module module*
+                                  #%require #%provide #%declare
+                                  quote-syntax)
+                   [(begin form ...)
+                    (syntax/loc/props e
+                      (begin (wrap-param-et form (orig-id ...) (temp-id ...)) ...))]
+                   [(define-syntaxes . _) e]
+                   [(begin-for-syntax . _) e]
+                   [(define-values ids rhs)
+                    (syntax/loc/props e
+                      (define-values ids (wrap-param-et rhs (orig-id ...) (temp-id ...))))]
+                   [(module . _) e]
+                   [(module* n #f form ...)
+                    (datum->syntax
+                     e
+                     (syntax-e #'(module* n #f (wrap-param-et form (orig-id ...) (temp-id ...)) ...))
+                     e
+                     e)]
+                   [(module* . _) e]
+                   [(#%require . _) e]
+                   [(#%provide . _) e]
+                   [(#%declare . _) e]
+                   [(quote-syntax . _) e]
+                   [else (as-expression)]))))])))])

--- a/hackett-lib/hackett/private/toplevel.rkt
+++ b/hackett-lib/hackett/private/toplevel.rkt
@@ -68,7 +68,8 @@
          racket/promise
          syntax/parse/define
 
-         (only-in hackett/private/base unmangle-types-in τ⇒! τ⇐!)
+         hackett/private/type-reqprov
+         (only-in hackett/private/base τ⇒! τ⇐!)
          (only-in (unmangle-types-in #:no-introduce hackett/private/kernel) String [#%app @%app])
          (only-in hackett/private/prim/base show)
          hackett/private/splicing)

--- a/hackett-lib/hackett/private/toplevel.rkt
+++ b/hackett-lib/hackett/private/toplevel.rkt
@@ -66,12 +66,12 @@
 
                      hackett/private/typecheck)
          racket/promise
-         racket/splicing
          syntax/parse/define
 
          (only-in hackett/private/base unmangle-types-in τ⇒! τ⇐!)
          (only-in (unmangle-types-in #:no-introduce hackett/private/kernel) String [#%app @%app])
-         (only-in hackett/private/prim/base show))
+         (only-in hackett/private/prim/base show)
+         hackett/private/splicing)
 
 (provide @%top-interaction)
 

--- a/hackett-lib/hackett/private/type-reqprov.rkt
+++ b/hackett-lib/hackett/private/type-reqprov.rkt
@@ -1,0 +1,94 @@
+#lang racket/base
+
+; This module implements require and provide transformers for mangling and unmangling type imports and
+; exports. This is necessary because Hackett has two namespaces: a type namespace, and a value
+; namespace. Within a module, this is easily accommodated by the hygiene system (each namespace has
+; its own unique scope), but when it comes to imports and exports, there is a problem. Specifically,
+; Racket modules only allow a single binding to be exported per symbol, per phase, so it’s impossible
+; to import two different bindings with the same name.
+;
+; To get around this, exports in the type namespace are mangled by the ‘type-out’ provide transformer,
+; then subsequently unmangled by the ‘unmangle-types-in’ require transformer. This mangling scheme
+; currently prepends ‘#%hackett-type:’ to the beginning of symbols, but that should be treated
+; entirely as an implementation detail, not a part of Hackett’s public interface.
+;
+; Generally, when writing Hackett code, this is all transparent. Hackett programmers export types
+; using ‘type-out’, and Hackett’s ‘require’ implicitly surrounds its subforms with
+; ‘unmangle-types-in’, so types are automatically injected into the proper namespace. This gets a bit
+; trickier, however, when interoperating with Racket modules, which obviously do not have a notion of
+; a type namespace. In this case, users must explicitly use ‘only-types-in’ or ‘unmangle-types-in’
+; with the ‘#:no-introduce’ or ‘#:prefix’ options in order to flatten the two Hackett namespaces into
+; Racket’s single one.
+
+(require (for-syntax racket/base
+                     racket/list
+                     racket/match
+                     racket/provide-transform
+                     racket/require-transform
+                     threading)
+         racket/provide
+         racket/require
+         syntax/parse/define
+
+         (for-syntax hackett/private/typecheck))
+
+(provide type-out only-types-in unmangle-types-in)
+
+(begin-for-syntax
+  (define (mangle-type-name name)
+    (string-append "#%hackett-type:" name))
+
+  (define mangled-type-regexp #rx"^#%hackett-type:(.+)$")
+  (define (unmangle-type-name name)
+    (and~> (regexp-match mangled-type-regexp name) second))
+  (define (unmangle-value-name name)
+    (and (not (regexp-match? mangled-type-regexp name)) name)))
+
+(define-syntax type-out
+  (make-provide-pre-transformer
+   (λ (stx modes)
+     (syntax-parse stx
+       [(_ {~optional {~and #:no-introduce no-introduce?}} provide-spec ...)
+        (pre-expand-export
+         #`(filtered-out mangle-type-name
+                         #,((if (attribute no-introduce?) values type-namespace-introduce)
+                            #'(combine-out provide-spec ...)))
+         modes)]))))
+
+(define-syntax only-types-in
+  (make-require-transformer
+   (syntax-parser
+     [(_ require-spec ...)
+      (expand-import
+       #`(filtered-in (λ (name) (and (regexp-match? mangled-type-regexp name) name))
+                      (combine-in require-spec ...)))])))
+
+(define-syntax unmangle-types-in
+  (make-require-transformer
+   (syntax-parser
+     [(_ {~or {~optional {~or {~and #:no-introduce no-introduce?}
+                              {~seq #:prefix prefix:id}}}}
+         require-spec ...)
+      #:do [(define-values [imports sources] (expand-import #'(combine-in require-spec ...)))]
+      (values (map (match-lambda
+                     [(and i (import local-id src-sym src-mod-path mode req-mode orig-mode orig-stx))
+                      (let* ([local-name (symbol->string (syntax-e local-id))]
+                             [unmangled-type-name (unmangle-type-name local-name)])
+                        (if unmangled-type-name
+                            (let* ([prefixed-type-name
+                                    (if (attribute prefix)
+                                        (string-append (symbol->string (syntax-e #'prefix))
+                                                       unmangled-type-name)
+                                        unmangled-type-name)]
+                                   [unmangled-id (datum->syntax local-id
+                                                                (string->symbol prefixed-type-name)
+                                                                local-id
+                                                                local-id)])
+                              (import (if (or (attribute no-introduce?)
+                                              (attribute prefix))
+                                          unmangled-id
+                                          (type-namespace-introduce unmangled-id))
+                                      src-sym src-mod-path mode req-mode orig-mode orig-stx))
+                            i))])
+                   imports)
+              sources)])))

--- a/hackett-lib/hackett/private/util/cond-expand.rkt
+++ b/hackett-lib/hackett/private/util/cond-expand.rkt
@@ -1,0 +1,21 @@
+#lang racket/base
+
+(require (for-syntax racket/base
+                     racket/syntax
+                     version/utils)
+         syntax/parse/define)
+
+(provide (for-syntax (all-from-out version/utils))
+         cond-expand)
+
+(define-syntax-parser cond-expand
+  #:literals [else]
+  [(_ {~and clause [{~and {~not else} clause-cond:expr} clause-form ...]} ...
+      {~optional [else else-form ...] #:defaults ([[else-form 1] (list #'(begin))])})
+   (or (for/or ([clause (in-list (attribute clause))]
+                [clause-cond (in-list (attribute clause-cond))]
+                [clause-forms (in-list (attribute clause-form))])
+         (and (syntax-local-eval clause-cond)
+              (quasisyntax/loc clause
+                (begin #,@clause-forms))))
+       #'(begin else-form ...))])

--- a/hackett-test/hackett/private/test.rkt
+++ b/hackett-test/hackett/private/test.rkt
@@ -12,7 +12,7 @@
            (prefix-in r: rackunit/log)
            syntax/parse/define
 
-           (only-in hackett/private/base submodule-part unmangle-types-in only-types-in)
+           (only-in hackett/private/base module+ unmangle-types-in only-types-in)
            (prefix-in t: (unmangle-types-in #:no-introduce (only-types-in hackett)))
            (only-in hackett [#%app @%app] : Unit Tuple)
            (only-in hackett/private/prim IO unsafe-run-io!)
@@ -36,9 +36,10 @@
 
   (define-syntax-parser test
     [(_ e:expr)
-     ; transfer lexical context onto module body to ensure the proper #%module-begin is introduced
-     #`(submodule-part test
-         #,(datum->syntax this-syntax (syntax-e #'(#%app void (force (@%app unsafe-run-io! e))))))]))
+     ; transfer lexical context to ensure the proper #%module-begin is introduced
+     (datum->syntax this-syntax
+                    (list #'module+ #'test #'(#%app void (force (@%app unsafe-run-io! e))))
+                    this-syntax)]))
 
 (require (submod "." shared)
          (submod "." untyped))

--- a/hackett-test/hackett/private/test.rkt
+++ b/hackett-test/hackett/private/test.rkt
@@ -12,9 +12,9 @@
            (prefix-in r: rackunit/log)
            syntax/parse/define
 
-           (only-in hackett/private/base module+ unmangle-types-in only-types-in)
+           (only-in hackett/private/base unmangle-types-in only-types-in)
            (prefix-in t: (unmangle-types-in #:no-introduce (only-types-in hackett)))
-           (only-in hackett [#%app @%app] : Unit Tuple)
+           (only-in hackett [#%app @%app] module+ : Unit Tuple)
            (only-in hackett/private/prim IO unsafe-run-io!)
            hackett/private/prim/type-provide
 

--- a/hackett-test/hackett/private/test.rkt
+++ b/hackett-test/hackett/private/test.rkt
@@ -12,7 +12,7 @@
            (prefix-in r: rackunit/log)
            syntax/parse/define
 
-           (only-in hackett/private/base unmangle-types-in only-types-in)
+           hackett/private/type-reqprov
            (prefix-in t: (unmangle-types-in #:no-introduce (only-types-in hackett)))
            (only-in hackett [#%app @%app] module+ : Unit Tuple)
            (only-in hackett/private/prim IO unsafe-run-io!)

--- a/hackett-test/hackett/private/test.rkt
+++ b/hackett-test/hackett/private/test.rkt
@@ -12,27 +12,27 @@
            (prefix-in r: rackunit/log)
            syntax/parse/define
 
-           (only-in hackett/private/base submodule-part unmangle-types-in)
-           (only-in (unmangle-types-in #:no-introduce hackett)
-                    [#%app @%app] : -> IO String Unit unit tuple)
-           (only-in hackett/private/prim io unsafe-run-io!)
+           (only-in hackett/private/base submodule-part unmangle-types-in only-types-in)
+           (prefix-in t: (unmangle-types-in #:no-introduce (only-types-in hackett)))
+           (only-in hackett [#%app @%app] : Unit Tuple)
+           (only-in hackett/private/prim IO unsafe-run-io!)
            hackett/private/prim/type-provide
 
            (unmangle-types-in #:no-introduce (submod ".." shared)))
 
-  (provide (typed-out [test-log! : {Test-Result -> (IO Unit)}]
-                      [println/error : {String -> (IO Unit)}])
+  (provide (typed-out [test-log! : {Test-Result t:-> (t:IO t:Unit)}]
+                      [println/error : {t:String t:-> (t:IO t:Unit)}])
            test)
 
   (define (test-log! result)
-    (io (λ (rw)
+    (IO (λ (rw)
           (r:test-log! (equal? test-success (force result)))
-          ((tuple rw) unit))))
+          ((Tuple rw) Unit))))
 
   (define (println/error str)
-    (io (λ (rw)
+    (IO (λ (rw)
           (displayln (force str) (current-error-port))
-          ((tuple rw) unit))))
+          ((Tuple rw) Unit))))
 
   (define-syntax-parser test
     [(_ e:expr)

--- a/hackett-test/tests/hackett/integration/multi-param-typeclasses.rkt
+++ b/hackett-test/tests/hackett/integration/multi-param-typeclasses.rkt
@@ -12,4 +12,4 @@
   [coerce integer->double])
 
 (test {(: (coerce 5) String) ==! "5"})
-(test {{{5.0 d- (coerce 5)} d< 0.1} ==! true})
+(test {{{5.0 d- (coerce 5)} d< 0.1} ==! True})

--- a/hackett-test/tests/hackett/regression/github-issue-36.rkt
+++ b/hackett-test/tests/hackett/regression/github-issue-36.rkt
@@ -2,4 +2,4 @@
 
 (require hackett/private/test)
 
-(test {(show (tuple 1 "str")) ==! "(tuple 1 \"str\")"})
+(test {(show (Tuple 1 "str")) ==! "(Tuple 1 \"str\")"})

--- a/hackett-test/tests/hackett/typecheck.rkt
+++ b/hackett-test/tests/hackett/typecheck.rkt
@@ -40,13 +40,13 @@
 
 (require (submod "." assertions))
 
-(typecheck-succeed unit)
-(typecheck-succeed (: unit Unit))
+(typecheck-succeed Unit)
+(typecheck-succeed (: Unit Unit))
 (typecheck-succeed 1)
 (typecheck-succeed (: 1 Integer))
-(typecheck-fail (: unit Integer))
+(typecheck-fail (: Unit Integer))
 (typecheck-fail (: 1 Unit))
-(typecheck-fail (unit unit))
+(typecheck-fail (Unit Unit))
 (typecheck-fail (1 1))
 
 (typecheck-succeed 1.0)
@@ -62,115 +62,115 @@
 
 (typecheck-succeed (λ [x] x))
 (typecheck-succeed (λ [x y] x))
-(typecheck-succeed ((λ [x] x) unit))
-(typecheck-succeed (: ((λ [x] x) unit) Unit))
+(typecheck-succeed ((λ [x] x) Unit))
+(typecheck-succeed (: ((λ [x] x) Unit) Unit))
 (typecheck-succeed ((λ [x] x) 1))
 (typecheck-succeed (: ((λ [x] x) 1) Integer))
-(typecheck-succeed ((λ [x y] x) unit 1))
-(typecheck-succeed (: ((λ [x y] x) unit 1) Unit))
-(typecheck-succeed ((λ [x y] y) unit 1))
-(typecheck-succeed (: ((λ [x y] y) unit 1) Integer))
+(typecheck-succeed ((λ [x y] x) Unit 1))
+(typecheck-succeed (: ((λ [x y] x) Unit 1) Unit))
+(typecheck-succeed ((λ [x y] y) Unit 1))
+(typecheck-succeed (: ((λ [x y] y) Unit 1) Integer))
 
 (typecheck-fail (: (λ [x] x) Unit))
 (typecheck-fail (: ((λ [x] x) 1) Unit))
 (typecheck-fail (: ((λ [x y] x) 1) Unit))
 (typecheck-fail (: ((λ [x y] y) 1) Unit))
 
-(typecheck-succeed (tuple unit unit))
-(typecheck-succeed (: (tuple unit unit) (Tuple Unit Unit)))
-(typecheck-succeed (tuple 1 1))
-(typecheck-succeed (: (tuple 1 1) (Tuple Integer Integer)))
-(typecheck-succeed (tuple 1 unit))
-(typecheck-succeed (: (tuple 1 unit) (Tuple Integer Unit)))
-(typecheck-succeed (tuple unit 1))
-(typecheck-succeed (: (tuple unit 1) (Tuple Unit Integer)))
+(typecheck-succeed (Tuple Unit Unit))
+(typecheck-succeed (: (Tuple Unit Unit) (Tuple Unit Unit)))
+(typecheck-succeed (Tuple 1 1))
+(typecheck-succeed (: (Tuple 1 1) (Tuple Integer Integer)))
+(typecheck-succeed (Tuple 1 Unit))
+(typecheck-succeed (: (Tuple 1 Unit) (Tuple Integer Unit)))
+(typecheck-succeed (Tuple Unit 1))
+(typecheck-succeed (: (Tuple Unit 1) (Tuple Unit Integer)))
 
-(typecheck-fail (: (tuple unit unit) (Tuple Integer Integer)))
-(typecheck-fail (: (tuple unit unit) (Tuple Unit Integer)))
-(typecheck-fail (: (tuple unit unit) (Tuple Integer Unit)))
+(typecheck-fail (: (Tuple Unit Unit) (Tuple Integer Integer)))
+(typecheck-fail (: (Tuple Unit Unit) (Tuple Unit Integer)))
+(typecheck-fail (: (Tuple Unit Unit) (Tuple Integer Unit)))
 
 (typecheck-succeed (: (λ [x] x) (∀ [a] {a -> a})))
 (typecheck-fail (: (λ [x] 1) (∀ [a] {a -> a})))
 (typecheck-succeed (: (λ [x y] x) (∀ [a b] {a -> b -> a})))
 (typecheck-fail (: (λ [x y] y) (∀ [a b] {a -> b -> a})))
 
-(typecheck-succeed true)
-(typecheck-succeed (: true Bool))
-(typecheck-succeed false)
-(typecheck-succeed (: false Bool))
-(typecheck-fail (: true Unit))
-(typecheck-fail (: false Unit))
+(typecheck-succeed True)
+(typecheck-succeed (: True Bool))
+(typecheck-succeed False)
+(typecheck-succeed (: False Bool))
+(typecheck-fail (: True Unit))
+(typecheck-fail (: False Unit))
 
-(typecheck-succeed just)
-(typecheck-succeed (: just (∀ [a] {a -> (Maybe a)})))
-(typecheck-succeed (: just {Unit -> (Maybe Unit)}))
-(typecheck-succeed (just unit))
-(typecheck-succeed (: (just unit) (Maybe Unit)))
-(typecheck-succeed nothing)
-(typecheck-succeed (: nothing (∀ [a] (Maybe a))))
-(typecheck-succeed (: nothing (Maybe Unit)))
-(typecheck-fail (: just (Maybe Unit)))
-(typecheck-fail (: (just unit) (∀ [a] (Maybe a))))
-(typecheck-fail (: (just unit) (Maybe Integer)))
-(typecheck-fail (: nothing Unit))
-(typecheck-fail (: (: nothing (Maybe Unit)) (∀ [a] (Maybe a))))
-(typecheck-fail (: (: nothing (Maybe Unit)) (Maybe Integer)))
+(typecheck-succeed Just)
+(typecheck-succeed (: Just (∀ [a] {a -> (Maybe a)})))
+(typecheck-succeed (: Just {Unit -> (Maybe Unit)}))
+(typecheck-succeed (Just Unit))
+(typecheck-succeed (: (Just Unit) (Maybe Unit)))
+(typecheck-succeed Nothing)
+(typecheck-succeed (: Nothing (∀ [a] (Maybe a))))
+(typecheck-succeed (: Nothing (Maybe Unit)))
+(typecheck-fail (: Just (Maybe Unit)))
+(typecheck-fail (: (Just Unit) (∀ [a] (Maybe a))))
+(typecheck-fail (: (Just Unit) (Maybe Integer)))
+(typecheck-fail (: Nothing Unit))
+(typecheck-fail (: (: Nothing (Maybe Unit)) (∀ [a] (Maybe a))))
+(typecheck-fail (: (: Nothing (Maybe Unit)) (Maybe Integer)))
 
-(typecheck-succeed (case nothing
-                     [(just x) x]
-                     [nothing unit]))
-(typecheck-succeed (: (case nothing
-                        [(just x) x]
-                        [nothing unit])
+(typecheck-succeed (case Nothing
+                     [(Just x) x]
+                     [Nothing Unit]))
+(typecheck-succeed (: (case Nothing
+                        [(Just x) x]
+                        [Nothing Unit])
                       Unit))
 (typecheck-succeed (λ [x] (case x
-                            [(just x) x]
-                            [nothing unit])))
+                            [(Just x) x]
+                            [Nothing Unit])))
 (typecheck-succeed (: (λ [x] (case x
-                               [(just x) x]
-                               [nothing unit]))
+                               [(Just x) x]
+                               [Nothing Unit]))
                       (-> (Maybe Unit) Unit)))
 (typecheck-fail (: (λ [x] (case x
-                            [(just x) x]
-                            [nothing unit]))
+                            [(Just x) x]
+                            [Nothing Unit]))
                    (-> (Maybe Integer) Unit)))
 (typecheck-fail (: (λ [x] (case x
-                            [(just x) x]
-                            [nothing unit]))
+                            [(Just x) x]
+                            [Nothing Unit]))
                    (∀ [a] (-> (Maybe a) Unit))))
-(typecheck-succeed (case nothing
-                     [(just (just x)) x]
-                     [_ unit]))
-(typecheck-succeed (: (case nothing
-                        [(just (just x)) x]
-                        [_ unit])
+(typecheck-succeed (case Nothing
+                     [(Just (Just x)) x]
+                     [_ Unit]))
+(typecheck-succeed (: (case Nothing
+                        [(Just (Just x)) x]
+                        [_ Unit])
                       Unit))
-(typecheck-fail (case nothing
-                  [(just x) x]
-                  [(just (just x)) x]
-                  [_ unit]))
+(typecheck-fail (case Nothing
+                  [(Just x) x]
+                  [(Just (Just x)) x]
+                  [_ Unit]))
 (typecheck-fail (λ [x] (case x
-                         [nothing unit]
-                         [true unit])))
+                         [Nothing Unit]
+                         [True Unit])))
 
 (typecheck-succeed (λ [m] (case m
-                            [nothing nothing]
-                            [_ nothing])))
+                            [Nothing Nothing]
+                            [_ Nothing])))
 (typecheck-succeed (: (λ [m] (case m
-                               [nothing nothing]
-                               [_ nothing]))
+                               [Nothing Nothing]
+                               [_ Nothing]))
                       (∀ [a b] {(Maybe a) -> (Maybe b)})))
 (typecheck-succeed (λ [f m] (case m
-                              [(just x) (just (f x))]
-                              [nothing nothing])))
+                              [(Just x) (Just (f x))]
+                              [Nothing Nothing])))
 (typecheck-succeed (: (λ [f m] (case m
-                                 [(just x) (just (f x))]
-                                 [nothing nothing]))
+                                 [(Just x) (Just (f x))]
+                                 [Nothing Nothing]))
                       (∀ [a b] {{a -> b} -> (Maybe a) -> (Maybe b)})))
 
-(typecheck-succeed {just . (+ 1)})
-(typecheck-succeed (: {just . (+ 1)} {Integer -> (Maybe Integer)}))
-(typecheck-fail {just . 1})
+(typecheck-succeed {Just . (+ 1)})
+(typecheck-succeed (: {Just . (+ 1)} {Integer -> (Maybe Integer)}))
+(typecheck-fail {Just . 1})
 
 (typecheck-succeed (let ([x 1]) (+ x 1)))
 (typecheck-succeed (: (let ([x 1]) (+ x 1)) Integer))
@@ -197,19 +197,19 @@
 (typecheck-fail (letrec ([xs 42]) (take 4 xs)))
 (typecheck-fail (letrec ([xs {1 :: ys}] [ys 5]) xs))
 
-(typecheck-succeed (λ [xs] (case xs [_ unit])))
+(typecheck-succeed (λ [xs] (case xs [_ Unit])))
 (typecheck-succeed (λ [xs] (case xs
-                             [nil unit]
-                             [{_ :: _} unit])))
+                             [Nil Unit]
+                             [{_ :: _} Unit])))
 (typecheck-fail (λ [xs] (case xs
-                          [nil unit])))
+                          [Nil Unit])))
 (typecheck-succeed (λ [xs] (case xs
-                             [nil unit]
-                             [{_ :: _ :: _} unit]
-                             [{_ :: _} unit])))
+                             [Nil Unit]
+                             [{_ :: _ :: _} Unit]
+                             [{_ :: _} Unit])))
 (typecheck-fail (λ [xs] (case xs
-                          [nil unit]
-                          [{_ :: _ :: _} unit])))
+                          [Nil Unit]
+                          [{_ :: _ :: _} Unit])))
 (typecheck-fail (λ [xs] (case xs
-                          [{_ :: _ :: _} unit]
-                          [{_ :: _} unit])))
+                          [{_ :: _ :: _} Unit]
+                          [{_ :: _} Unit])))


### PR DESCRIPTION
This PR implements a separation of type and value namespaces, making it possible to reuse the same name in both a type and value context without one shadowing the other. There are various reasons to want this, but I think these are the strongest motivators:

  1. It allows data constructors to be upper case, a la Haskell, so we can have `(data (Tuple a b) (Tuple a b))`. This is nice, because it turns out that pattern-matching is too ambiguous without some convention to distinguish constructors from bindings.

     What happens when a user pattern-matches against the pattern `nil`, then `nil` is removed from the import list? The program should fail to compile, but it doesn’t—`nil` is simply bound to a fresh variable that matches against anything. Hopefully the exhaustiveness checker will save us (if we implement pattern redundancy checks), but there’s a possibility it would turn a correct program into a wrong one (that still compiles).

  2. Currently, it is not common for names to conflict, but that would likely change with the introduction of scoped type variables (#30). This cleanly eliminates that issue without users needing to adjust their programs.

  3. As long as Hackett is not dependently-typed (and there are no plans to make it dependently-typed, since I imagine that would make more sense as a separate `#lang`), there is simply no good reason *not* to have separate namespaces.

The core implementation strategy involves two things: a pair of syntax introducers that represent a value scope and a type scope, plus a name mangling scheme to get around the fact that Racket modules can only provide a single binding per symbolic name, per phase. In practice, this is a bit trickier than it seems, since there are a variety of hurdles to overcome, most notably interactions with `module*` submodules and Scribble documentation.

For some extra context, see [this discussion on the Racket users mailing list](https://groups.google.com/d/msg/racket-users/RD0qtXerwZo/R51Txbi_AAAJ).