### PR TITLE
Add TODO form representing incomplete programs

### DIFF
--- a/hackett-doc/scribblings/hackett/reference.scrbl
+++ b/hackett-doc/scribblings/hackett/reference.scrbl
@@ -1258,6 +1258,27 @@ will also be evaluated to weak head normal form. This can be used to reduce lazi
 
 A simple @tech{partial function} that crashes the program with a message when evaluated.}
 
+@subsection[#:tag "reference-incomplete-programs"]{Incomplete Programs}
+
 @defthing[undefined! (t:forall [a] a)]{
 
 A @tech[#:key "partial function"]{partial} value that crashes the program when evaluated.}
+
+@defform[(todo! form ...)]{
+
+A form that expands to a @tech[#:key "partial function"]{partial} value of type
+@racket[(t:forall [_a] _a)] that crashes the program with a message containing its expected type when
+evaluated. Uses of this form serve as an indicator that a part of the program is not yet written. The
+@racket[form]s provided to @racket[todo!] are ignored, allowing the contents to contain
+not-yet-working sketches and notes.
+
+@(hackett-examples
+  #:no-preserve-source-locations
+  (eval:error (not (todo!)))
+  (eval:error (+ 42 (todo!)))
+  (eval:error (+ 42 ((todo!) "hello"))))
+
+Additionally, @racket[todo!] attaches a syntax property containing its expected type to its expansion
+to cooperate with editors that know how to display that information. See
+@other-doc['(lib "todo-list/scribblings/todo-list.scrbl") #:indirect "Todo List for DrRacket"] for
+more details.}

--- a/hackett-lib/hackett/base.rkt
+++ b/hackett-lib/hackett/base.rkt
@@ -9,7 +9,6 @@
          (all-from-out hackett/private/class)
          (all-from-out hackett/private/kernel)
          (all-from-out hackett/private/provide)
-
          (rename-out [@%top-interaction #%top-interaction]))
 
 (module reader syntax/module-reader hackett/base

--- a/hackett-lib/hackett/private/kernel.rkt
+++ b/hackett-lib/hackett/private/kernel.rkt
@@ -20,7 +20,7 @@
                      [λ lambda])
          #%require/only-types combine-in except-in only-in prefix-in rename-in
          provide combine-out except-out prefix-out rename-out type-out module+
-         : def λ let letrec
+         : def λ let letrec todo!
          (type-out #:no-introduce ∀ -> => Integer Double String
                    (rename-out [@%top #%top]
                                [@%app #%app]


### PR DESCRIPTION
A "shed" is a region of a program that is not yet written, in which the programmer can write whatever they want. The intention behind sheds is that they be used for fancy interactive editing features. Haskell has a version of sheds, which they call "typed holes", that don't allow any contents. These ones are more similar to those found in Epigram or Agda.

At present, a shed macroexpands to a program that throws an error that lists the expected type. However, they also add a syntax property that tools such as the todo list can use to provide a list of sheds and their goal types.

Future enhancements can include diffing the type synthesized for the shed contents against the type expected for the shed itself, and adding the typing context to the message and/or goal. Sheds in types would also be nice. But this feature is, I think already useful as it currently is.