### PR TITLE
Typecheck case* bodies using ⇐ rule (fix #63)

### DIFF
--- a/hackett-lib/hackett/private/adt.rkt
+++ b/hackett-lib/hackett/private/adt.rkt
@@ -472,12 +472,15 @@
 
 (define-syntax-parser case*
   [(_ [val:expr ...+] {~var clause (case*-clause (length (attribute val)))} ...+)
-   #:do [; First, infer the types of each clause and expand the bodies. Each clause has N patterns,
-         ; each of which match against a particular type, and it also has a body, which must be
-         ; typechecked as well. Additionally, inferring the pattern types also produces a racket/match
-         ; pattern, which we can use to implement the untyped expansion.
-         (define-values [tss_pats match-pats- bodies- ts_bodies]
-           (for/lists [tss_pats match-pats- bodies- ts_bodies]
+   #:do [; Create a solver variable to unify with the type of the clause bodies.
+         ; TODO: recieve this type using the expected type given from ⇐ rules?
+         (define t_result (τ:var^ (generate-temporary)))
+
+         ; Typecheck the clauses and expand the bodies. Each clause has has N patterns, each of
+         ; which match against a particular type. Inferring the pattern types also produces a
+         ; racket/match pattern, which we can use to implement the untyped expansion.
+         (define-values [tss_pats match-pats- bodies-]
+           (for/lists [tss_pats match-pats- bodies-]
                       ([clause (in-list (attribute clause))]
                        [body (in-list (attribute clause.body))]
                        [pats (in-list (attribute clause.pat.pat))])
@@ -489,8 +492,8 @@
                      (pat⇒! pat))]
                   ; Collect the set of bindings introduced by the patterns.
                   [(assumps) (append* assumpss)]
-                  ; Infer the type of the body expression, as well as the bindings it introduces.
-                  [(bound-ids- body- t_body) (τ⇒/λ! body assumps)]
+                  ; Typecheck the body expression, which generates binding ids for the clause.
+                  [(bound-ids- body-) (τ⇐/λ! body t_result assumps)]
                   ; Use the bound ids to construct racket/match patterns from the case patterns.
                   [(match-pats- (list))
                    (for/fold ([match-pats- '()]
@@ -502,7 +505,7 @@
                   [(match-pat-) (quasisyntax/loc clause
                                   (#,@(reverse match-pats-)))])
                ; Return all the results of the inference process.
-               (values ts_pats match-pat- body- t_body))))
+               (values ts_pats match-pat- body-))))
 
          ; Now that we’ve inferred the types that each pattern can match against, we should infer the
          ; types of each value being matched and ensure that all the patterns match against it. In
@@ -512,7 +515,7 @@
          ; type errors errors.
          (define tss_pats-transposed (apply map list tss_pats))
          (define patss-transposed (apply map list (attribute clause.pat)))]
-   ; Now we can iterate over the types and ensure each value has the appropriate type.
+   ; Now we can iterate over the types and ensure each pattern has the appropriate type.
    #:with [val- ...] (for/list ([val (in-list (attribute val))]
                                 [ts_pats (in-list tss_pats-transposed)]
                                 [pats (in-list patss-transposed)])
@@ -528,14 +531,6 @@
                               (if (= (length non-exhaust) 1) "" "s")
                               ":" (string-append* (map #{string-append "\n    " (ideal->string %)}
                                                        non-exhaust)))
-
-   #:do [; Now that we’ve inferred the types for the patterns, the inputs, and the bodies, we need to
-         ; ensure all the body types actually agree. If they do, that will be the result type of the
-         ; whole expression.
-         (define t_result
-           (let ([result^ (generate-temporary)])
-             (for-each #{τ<:! %1 (τ:var^ result^) #:src %2} ts_bodies (attribute clause.body))
-             (apply-current-subst (τ:var^ result^))))]
 
    ; Finally, we can actually emit the result syntax, using racket/match.
    #:with [match-pat- ...] match-pats-


### PR DESCRIPTION
Instead of inferring each body then unifying them afterwards, use the left-arrow rule to check the body expressions against a solver variable created beforehand. This will open up the possibility to look at expected-type information to produce even better typechecking for `case*` expressions.

This fixes the qualification mess in #63, but I think a more "complete" solution would be to remove the `τ<:!` function entirely since it basically screws over constraints in general.