### PR TITLE
Typecheck clause bodies with τ⇐/λ! (fixes #63)

### DIFF
--- a/hackett-test/tests/hackett/regression/github-issue-63.rkt
+++ b/hackett-test/tests/hackett/regression/github-issue-63.rkt
@@ -1,0 +1,9 @@
+#lang hackett
+
+(require hackett/private/test)
+
+(defn fold-map : (forall [a b] (Monoid b) => {{a -> b} -> (List a) -> b})
+  [[_ Nil] mempty]
+  [[f {x :: xs}] {(f x) ++ (fold-map f xs)}])
+
+(test {(fold-map reverse {{1 :: 2 :: Nil} :: {3 :: 4 :: Nil} :: Nil}) ==! {2 :: 1 :: 4 :: 3 :: Nil}})


### PR DESCRIPTION
Rather than inferring the clause bodies with `τ⇒/λ!`, we typecheck them with `τ⇐/λ!` against the expected type (or a new solver variable). This provides better type information to the clause bodies, and additionally fixes #63. 

The exact reason for #63 likely had to do with `type<:!` refusing to unify against constraints. This seems to be because it does not have a term to attach appropriate `@%with-dictionary` forms to; for this reason `type<:!` should probably be avoided (after this commit it is used in only one place), unless it's certain that the unification will not involve constraints.