### PR TITLE
Implement type aliases

### DIFF
--- a/hackett-doc/scribblings/hackett/reference.scrbl
+++ b/hackett-doc/scribblings/hackett/reference.scrbl
@@ -315,7 +315,10 @@ specified controls the fixity used by the associated @racket[type-constructor-id
          (type type-clause type-expr)
          #:grammar
          ([type-clause name-id
-                       (code:line (name-id param-id ...+))])]{
+                       (code:line (name-id param-id ...+))]
+          [maybe-fixity-ann (code:line #:fixity fixity)
+                            (code:line)]
+          [fixity left right])]{
 
 Defines a @deftech{type alias} named @racket[name-id]. Uses of @racket[name-id] are equivalent to
 uses of the type specified in @racket[type-expr]. If @racket[type-clause] is a bare @racket[name-id],
@@ -326,11 +329,6 @@ then @racket[name-id] is bound directly to the type alias.
   (type Num Double)
   (def n : Num 1.5)
   (#:type n))
-
-@margin-note{
-  Type aliases with @racket[param-id]s can only be used with prefix notation, using
-  @racket[(name-id type-argument ...)] rather than
-  @racket[{type-argument name-id type-argument}].}
 
 If @racket[param-id]s are specified, then uses of the type alias must supply as many arguments as
 there are @racket[param-id]s. The arguments are supplied like those to a type constructor—i.e. 

--- a/hackett-doc/scribblings/hackett/reference.scrbl
+++ b/hackett-doc/scribblings/hackett/reference.scrbl
@@ -107,7 +107,7 @@ following combination of @racket[def], @racket[lambda], and @racket[case*]:
 The @racket[defn] form is generally preferred when defining top-level functions.
 
 @(hackett-examples
-  (defn square : (t:-> t:Integer t:Integer)
+  (defn square : {t:Integer t:-> t:Integer}
     [[x] {x * x}])
   (eval:check (square 5) 25))}
 
@@ -307,6 +307,49 @@ specified controls the fixity used by the associated @racket[type-constructor-id
               [[(Leaf a)] {"(Leaf " ++ (show a) ++ ")"}])])
   {(Leaf 1) :&: (Leaf 2) :&: (Leaf 3)})}
 @(close-eval data-examples-eval)
+
+@subsection[#:tag "reference-type-alias"]{Defining type aliases}
+
+@(define alias-examples-eval (make-hackett-eval))
+@defform[#:literals [left right]
+         (type type-clause type-expr)
+         #:grammar
+         ([type-clause name-id
+                       (code:line (name-id param-id ...+))])]{
+
+Defines a @deftech{type alias} named @racket[name-id]. Uses of @racket[name-id] are equivalent to
+uses of the type specified in @racket[type-expr]. If @racket[type-clause] is a bare @racket[name-id],
+then @racket[name-id] is bound directly to the type alias.
+
+@(hackett-examples
+  #:eval alias-examples-eval
+  (type Num Double)
+  (def n : Num 1.5)
+  (#:type n))
+
+@margin-note{
+  Type aliases with @racket[param-id]s can only be used with prefix notation, using
+  @racket[(name-id type-argument ...)] rather than
+  @racket[{type-argument name-id type-argument}].}
+
+If @racket[param-id]s are specified, then uses of the type alias must supply as many arguments as
+there are @racket[param-id]s. The arguments are supplied like those to a type constructor—i.e. 
+@racket[(name-id type-argument ...)]—and the resulting type is @racket[type-expr] with each
+@racket[param-id] substituted with the corresponding @racket[type-argument].
+
+Though the application of a type alias is syntactically similar to the application of a type
+constructor, type aliases are effectively type-level macros, and they may not be partially applied.
+All uses of a type alias must be fully saturated.
+
+@(hackett-examples
+  #:eval alias-examples-eval
+  (type (Predicate a) {a t:-> t:Bool})
+  (def zero? : (Predicate t:Integer) (== 0))
+  (#:type zero?)
+  (eval:check (zero? 0) True)
+  (eval:check ((: zero? (Predicate t:Integer)) 0) True)
+  (eval:error (: zero? Predicate)))
+@(close-eval alias-examples-eval)}
 
 @subsection[#:tag "reference-numbers"]{Numbers}
 

--- a/hackett-lib/hackett/base.rkt
+++ b/hackett-lib/hackett/base.rkt
@@ -1,11 +1,13 @@
 #lang racket/base
 
 (require (only-in hackett/private/adt case* case λ λ* lambda lambda* defn _)
+         (only-in hackett/private/type-alias type)
          (only-in hackett/private/class instance derive-instance)
          (except-in hackett/private/kernel λ lambda)
          hackett/private/provide
          (only-in hackett/private/toplevel @%top-interaction))
 (provide (all-from-out hackett/private/adt)
+         (all-from-out hackett/private/type-alias)
          (all-from-out hackett/private/class)
          (all-from-out hackett/private/kernel)
          (all-from-out hackett/private/provide)

--- a/hackett-lib/hackett/private/infix.rkt
+++ b/hackett-lib/hackett/private/infix.rkt
@@ -35,7 +35,9 @@
 (define (infix-operator? x)
   (and (has-prop:infix-operator? x)
        (operator-fixity? (infix-operator-fixity x))))
-  
+
+; Infix transformer bindings; use the make-infix-variable-like-transformer constructor instead of
+; creating instances of this struct directly.
 (struct infix-variable-like-transformer (procedure fixity)
   #:property prop:procedure (struct-field-index procedure)
   #:property prop:infix-operator

--- a/hackett-lib/hackett/private/kernel.rkt
+++ b/hackett-lib/hackett/private/kernel.rkt
@@ -90,23 +90,18 @@
    (begin
      (define-syntax-parser @%app
        [(~parens _ . args)
-        (syntax/loc this-syntax
-          (@%app/prefix . args))]
+        (datum->syntax this-syntax (cons #'@%app/prefix #'args) this-syntax)]
        [{~braces _ . args}
-        (syntax/loc this-syntax
-          (@%app/infix . args))])
+        (datum->syntax this-syntax (cons #'@%app/infix #'args) this-syntax)])
 
      (define-syntax-parser @%app/prefix
        [(_ f:expr) #'f]
        [(_ f:expr x:expr)
-        (syntax/loc this-syntax
-          (@%app1 f x))]
+        (datum->syntax this-syntax (list #'@%app1 #'f #'x) this-syntax)]
        [(_ f:expr x:expr xs:expr ...)
-        (quasisyntax/loc this-syntax
-          (@%app/prefix #,(~> (syntax/loc this-syntax
-                                (@%app1 f x))
-                              (syntax-property 'omit-type-tooltip #t))
-                        xs ...))])
+        #:with inner-app (~> (datum->syntax this-syntax (list #'@%app1 #'f #'x) this-syntax)
+                             (syntax-property 'omit-type-tooltip #t))
+        (datum->syntax this-syntax (list* #'@%app/prefix #'inner-app #'(xs ...)) this-syntax)])
 
      (define-syntax-parser @%app/infix
        [(_ a:expr op:infix-operator b:expr {~seq ops:infix-operator bs:expr} ...+)
@@ -114,24 +109,26 @@
         #:and ~!
         #:fail-unless (andmap #{eq? % 'left} (attribute ops.fixity))
                       "cannot mix left- and right-associative operators in the same infix expression"
-        (quasitemplate/loc this-syntax
-          (@%app/infix #,(~> (syntax/loc this-syntax
-                               (@%app/infix a op b))
+        #:with inner-app (~> (datum->syntax this-syntax (list #'@%app/infix #'a #'op #'b) this-syntax)
                              (syntax-property 'omit-type-tooltip #t))
-                       {?@ ops bs} ...))]
+        (~> (list* #'@%app/infix #'inner-app (syntax->list #'({?@ ops bs} ...)))
+            (datum->syntax this-syntax _ this-syntax))]
        [(_ {~seq as:expr ops:infix-operator} ...+ a:expr op:infix-operator b:expr)
         #:when (eq? 'right (attribute op.fixity))
         #:and ~!
         #:fail-unless (andmap #{eq? % 'right} (attribute ops.fixity))
                       "cannot mix left- and right-associative operators in the same infix expression"
-        (quasitemplate/loc this-syntax
-          (@%app/infix {?@ as ops} ...
-                       #,(~> (syntax/loc this-syntax
-                               (@%app/infix a op b))
-                             (syntax-property 'omit-type-tooltip #t))))]
+        #:with inner-app (~> (datum->syntax this-syntax (list #'@%app/infix #'a #'op #'b) this-syntax)
+                             (syntax-property 'omit-type-tooltip #t))
+        (~> (append (list #'@%app/infix) (syntax->list #'({?@ as ops} ...)) (list #'inner-app))
+            (datum->syntax this-syntax _ this-syntax))]
        [(_ a:expr op:expr b:expr)
-        (syntax/loc this-syntax
-          (@%app/prefix op a b))]
+        (quasisyntax/loc this-syntax
+          (#%expression
+           #,(~> (datum->syntax this-syntax (list #'op #'a #'b) this-syntax)
+                 ; Explicitly make 'paren-shape #f on the new application form to avoid the #\{ value
+                 ; being copied onto the prefix application when #%expression is expanded.
+                 (syntax-property 'paren-shape #f))))]
        [(_ a:expr)
         #'a]))))
 

--- a/hackett-test/tests/hackett/integration/type-alias.rkt
+++ b/hackett-test/tests/hackett/integration/type-alias.rkt
@@ -29,3 +29,10 @@
 
 (test {{4 int= 6} ==! False})
 (test {{4 int= 4} ==! True})
+
+(type {a ~> b} #:fixity right {a -> (Maybe b)})
+
+(def head* : (forall [a] {(List a) ~> a}) head)
+
+(test {(head* {1 :: Nil}) ==! (Just 1)})
+(test {(head* {Nil : (List Integer)}) ==! Nothing})

--- a/hackett-test/tests/hackett/integration/type-alias.rkt
+++ b/hackett-test/tests/hackett/integration/type-alias.rkt
@@ -1,0 +1,31 @@
+#lang hackett
+
+(require hackett/private/test
+         (only-in racket/base submod)
+         (submod tests/hackett/typecheck assertions))
+
+(type X Integer)
+(def x : X 5)
+(typecheck-fail (: "" X))
+
+(type (Arr a b) {a -> b})
+(type (Pred a) (Arr a Bool))
+(type (BiRel a) {a -> a -> Bool})
+
+(type Y (forall [a b] (Monoid b) => (Either a b)))
+
+(typecheck-fail
+ (λ ([x : (Arr Bool)]) ; not enough args to alias
+   x))
+
+(defn never : (forall [a] (Pred a))
+  [[x] False])
+
+(test {(never 5) ==! False})
+(test {(never "asdasaf") ==! False})
+
+(def int= : (BiRel Integer)
+  ==)
+
+(test {{4 int= 6} ==! False})
+(test {{4 int= 4} ==! True})


### PR DESCRIPTION
Adds a `type` form for type aliases.
```racket
(type name-id maybe-fixity type-expr)
(type (name-id param-id ...) type-expr)
```

 
 - [x]  document `type`