### PR TITLE
Add case-pattern expanders

### DIFF
--- a/hackett-lib/hackett/base.rkt
+++ b/hackett-lib/hackett/base.rkt
@@ -2,12 +2,14 @@
 
 (require (only-in hackett/private/adt case* case λ λ* lambda lambda* defn _)
          (only-in hackett/private/type-alias type)
+         (only-in hackett/private/pattern-alias pattern List)
          (only-in hackett/private/class instance derive-instance)
          (except-in hackett/private/kernel λ lambda)
          hackett/private/provide
          (only-in hackett/private/toplevel @%top-interaction))
 (provide (all-from-out hackett/private/adt)
          (all-from-out hackett/private/type-alias)
+         (all-from-out hackett/private/pattern-alias)
          (all-from-out hackett/private/class)
          (all-from-out hackett/private/kernel)
          (all-from-out hackett/private/provide)

--- a/hackett-lib/hackett/private/adt.rkt
+++ b/hackett-lib/hackett/private/adt.rkt
@@ -5,9 +5,11 @@
          (for-syntax (multi-in racket [base contract string format list match syntax])
                      (multi-in syntax/parse [class/local-value class/paren-shape
                                              experimental/template])
+                     syntax/apply-transformer
                      threading
 
                      hackett/private/infix
+                     hackett/private/prop-case-pattern-expander
                      hackett/private/util/list
                      hackett/private/util/stx)
 
@@ -207,6 +209,14 @@
     #:description "a pattern"
     #:attributes [pat disappeared-uses]
     #:commit
+
+    [pattern {~and pat-exp
+                   {~or pat-id (pat-id . _)}}
+             #:declare pat-id (local-value case-pattern-expander?)
+             #:do [(define trans
+                     (case-pattern-expander-transformer (attribute pat-id.local-value)))]
+             #:with :pat (local-apply-transformer trans #'pat-exp 'expression)]
+
     [pattern {~and constructor:data-constructor-val ~!}
              #:do [(define val (attribute constructor.local-value))
                    (define arity (data-constructor-arity val))]

--- a/hackett-lib/hackett/private/pattern-alias.rkt
+++ b/hackett-lib/hackett/private/pattern-alias.rkt
@@ -1,0 +1,37 @@
+#lang racket/base
+
+(provide pattern List)
+
+(require syntax/parse/define
+         (only-in hackett/private/adt defn)
+         (only-in hackett/private/prim/type Nil ::)
+         (only-in hackett/private/kernel #%app)
+         (for-syntax racket/base
+                     racket/syntax
+                     syntax/parse
+                     hackett/private/prop-case-pattern-expander
+                     hackett/private/util/stx))
+
+(begin-for-syntax
+  (struct proc+case-pat-exp [proc case-pat-trans]
+    #:property prop:procedure (struct-field-index proc)
+    #:property prop:case-pattern-expander
+    (λ (self) (proc+case-pat-exp-case-pat-trans self))))
+
+(define-simple-macro
+  (pattern (head:id arg:id ...) old:expr)
+  #:with head-internal (generate-temporary #'head)
+  (begin
+    (defn head-internal [[arg ...] old])
+    (define-syntax head
+      (proc+case-pat-exp
+       (make-variable-like-transformer (quote-syntax head-internal))
+       (syntax-parser #:disable-colon-notation
+         [({~var head} {~var arg} ...) #'old])))))
+
+(define-syntax List
+  (let ([trans
+         (syntax-parser
+           [(List)          #'Nil]
+           [(List a bs ...) #'(:: a (List bs ...))])])
+    (proc+case-pat-exp trans trans)))

--- a/hackett-lib/hackett/private/prop-case-pattern-expander.rkt
+++ b/hackett-lib/hackett/private/prop-case-pattern-expander.rkt
@@ -1,0 +1,41 @@
+#lang racket/base
+
+(require racket/contract/base)
+(provide (contract-out
+          [prop:case-pattern-expander
+           (struct-type-property/c (-> any/c (-> syntax? syntax?)))]
+          [case-pattern-expander?
+           (-> any/c boolean?)]
+          [case-pattern-expander
+           (-> (-> syntax? syntax?) case-pattern-expander?)]
+          [case-pattern-expander-transformer
+           (-> case-pattern-expander? (-> syntax? syntax?))]))
+
+(require racket/local)
+
+;; prop:case-pattern-expander is a struct-type-property
+;; that contains one of:
+;;  - [Self -> [Syntax -> Syntax]]
+
+;; case-pattern-expander? : Any -> Boolean : CasePatternExpander
+
+;; case-pattern-expander : [Syntax -> Syntax] -> CasePatternExpander
+
+;; case-pattern-expander-transformer : CasePatternExpander -> [Syntax -> Syntax]
+
+(define-values [prop:case-pattern-expander
+                case-pattern-expander?
+                case-pattern-expander-ref]
+  (make-struct-type-property 'case-pattern-expander))
+
+(define case-pattern-expander
+  (local [(struct case-pattern-expander [transformer]
+            #:property prop:case-pattern-expander
+            (λ (self) (case-pattern-expander-transformer self)))]
+    case-pattern-expander))
+
+(define (case-pattern-expander-transformer cpe)
+  (define get-transformer
+    (case-pattern-expander-ref cpe))
+  (get-transformer cpe))
+

--- a/hackett-lib/info.rkt
+++ b/hackett-lib/info.rkt
@@ -3,7 +3,7 @@
 (define collection 'multi)
 
 (define deps
-  '(["base" #:version "6.90.0.28"]
+  '(["base" #:version "6.90.0.30"]
     "curly-fn-lib"
     "data-lib"
     "syntax-classes-lib"

--- a/hackett-test/tests/hackett/integration/pattern-alias.rkt
+++ b/hackett-test/tests/hackett/integration/pattern-alias.rkt
@@ -1,0 +1,61 @@
+#lang hackett
+(require hackett/private/test)
+
+;; Exp* is like an "Exp/recur"
+
+(data (Exp* e)
+  (Var* String)
+  (App* e e)
+  (Lam* String e)
+  #:deriving [Show])
+
+(instance (Functor Exp*)
+  [<$>
+   (λ* [[f (Var* x)] (Var* x)]
+       [[f (App* a b)] (App* (f a) (f b))]
+       [[f (Lam* x a)] (Lam* x (f a))])])
+
+#;
+(instance (forall [e] (Show e) => (Show (Exp* e)))
+  [show
+   (λ* [[(Var* x)] {"(Var " ++ (show x) ++ ")"}]
+       [[(App* a b)] {"(App " ++ (show a) ++ " " ++ (show b) ++ ")"}]
+       [[(Lam* x a)] {"(Lam " ++ (show x) ++ " " ++ (show a) ++ ")"}])])
+
+;; ------------------------------------------
+
+(data Exp
+  (E (Exp* Exp)))
+
+(instance (Show Exp)
+  [show (λ* [[(E e)] (show e)])])
+
+(pattern (Var x)   (E (Var* x)))
+(pattern (App a b) (E (App* a b)))
+(pattern (Lam x a) (E (Lam* x a)))
+
+(def example : Exp
+  (App (Var "x")
+       (Var "y")))
+
+(defn getVar : {Exp -> String}
+  [[(Var x)] x]
+  [[_] (error! "not a variable")])
+
+(defn free : {Exp -> (List String)}
+    [[(Var x)] (List x)]
+    [[(App f a)] {(free f) ++ (free a)}]
+    [[(Lam x b)] (filter (/= x) (free b))])
+
+;; ------------------------------------------
+
+(test {(show example) ==! "(App* (Var* \"x\") (Var* \"y\"))"})
+(test {(getVar (Var "z")) ==! "z"})
+(test {(getVar (E (Var* "z"))) ==! "z"})
+
+(test {(free (Var "x")) ==! (List "x")})
+(test {(free (App (Lam "x" (App (Var "x") (Var "y")))
+                  (Lam "z" (App (Var "a") (Var "z")))))
+       ==!
+       (List "y" "a")})
+

--- a/hackett-test/tests/hackett/integration/variadic-list.rkt
+++ b/hackett-test/tests/hackett/integration/variadic-list.rkt
@@ -1,0 +1,12 @@
+#lang hackett
+(require hackett/private/test)
+
+(def my-empty : (forall [a] (List a)) (List))
+
+(defn last : (forall [a] {(List a) -> a})
+  [[(List)]    (error! "last of empty list")]
+  [[(List x)]  x]
+  [[{x :: xs}] (last xs)])
+
+(test {(List 1 2 3) ==! {1 :: 2 :: 3 :: Nil}})
+(test {(head! (last (List (List 8 9) (List 10 100)))) ==! 10})


### PR DESCRIPTION
Closes #75, relying on https://github.com/racket/racket/pull/2082 for `local-apply-transformer`.