### PR TITLE
Allow pattern expansion in "head" positions of case-patterns

### DIFF
--- a/hackett-test/tests/hackett/integration/pattern-app.rkt
+++ b/hackett-test/tests/hackett/integration/pattern-app.rkt
@@ -1,0 +1,52 @@
+#lang hackett
+
+(require hackett/private/test
+         (only-in racket/base
+           define-syntax for-syntax begin-for-syntax)
+         (for-syntax racket/base
+                     syntax/parse
+                     (only-in hackett/private/prop-case-pattern-expander
+                       case-pattern-expander)))
+
+(begin-for-syntax
+  (struct group [hash])
+  (define (group-ref g x)
+    (hash-ref (group-hash g) x)))
+
+(define-syntax group-ref
+  (case-pattern-expander
+   (syntax-parser
+     [(_ {~var G (static group? "group")} x)
+      (group-ref (attribute G.value) (syntax-e #'x))])))
+
+(data Result
+  (Success Integer)
+  (Failure String))
+
+(define-syntax G (group (hash 'good #'Success 'bad #'Failure)))
+
+(test {(case (Success 5)
+         [((group-ref G good) x) (Just x)]
+         [((group-ref G bad) y) Nothing])
+       ==!
+       (Just 5)})
+
+(data T (C Integer Integer))
+
+(define-syntax n
+  (case-pattern-expander
+   (syntax-parser
+     [(n) #'m])))
+
+(define-syntax m
+  (case-pattern-expander
+   (syntax-parser
+     [:id #'C]
+     [(_ . _)
+      (raise-syntax-error #f "must use `m` as an identifier" this-syntax)])))
+
+(test {(case (C 1 2)
+         [((n) x y) x])
+       ==!
+       1})
+


### PR DESCRIPTION
So that a pattern can expand in the place of a constructor in something like:
```racket
(case x
  [((case-pat-expander arg ...) sub-pat ...) body])
```
If `(case-pat-expander arg ...)` expands into a constructor `C`, then this is now equivalent to:
```racket
(case x
  [(C sub-pat ...) body])
```