### PR TITLE
[WIP] Multi-pass elaboration & functional dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
 before_install:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-  - git clone https://github.com/greghendershott/travis-racket.git
+  - git clone -b utah --depth 1 https://github.com/lexi-lambda/travis-racket.git
   - cat travis-racket/install-racket.sh | bash
   - export PATH="${RACKET_DIR}/bin:${PATH}"
 

--- a/hackett-doc/scribblings/hackett/reference.scrbl
+++ b/hackett-doc/scribblings/hackett/reference.scrbl
@@ -835,13 +835,17 @@ Adds the elements of @racket[xs] together and returns the sum. Equivalent to @ra
 
 @subsection[#:tag "reference-defining-typeclasses"]{Defining typeclasses and typeclass instances}
 
-@defform[#:literals [: t:=>]
+@defform[#:literals [: t:=> t:->]
          (class maybe-superclasses (class-id var-id ...)
+           maybe-fundeps
            [method-id : method-type maybe-default-method-impl] ...
            maybe-deriving-transformer)
          #:grammar
          ([maybe-superclasses (code:line superclass-constraint ... t:=>)
                               (code:line)]
+          [maybe-fundeps (code:line #:fundeps [fundep-spec ...])
+                         (code:line)]
+          [fundep-spec [determinant-id ...+ t:-> dependent-id ...+]]
           [maybe-default-method-impl default-method-impl-expr
                                      (code:line)]
           [maybe-deriving-transformer (code:line #:deriving-transformer deriving-transformer-expr)
@@ -863,6 +867,35 @@ valid implementation for any instance of the class. Default methods are generall
 typeclass method may be defined in terms of other typeclass methods, but the implementor can be given
 a choice of which methods to implement, or they can provide a more efficient implementation for
 commonly-used methods.
+
+Each @racket[fundep-spec], if provided, declares a @deftech{functional dependency} between parameters
+of the class, where each @racket[determinant-id] and @racket[dependent-id] must be included in the
+class’s @racket[var-id]s. A functional dependency introduces a constraint between instances of the
+class: each combination of the parameters specified by the @racket[determinant-id]s must uniquely
+determine the parameters specified by the @racket[dependent-id]s. For example, given the following
+class declaration:
+
+@(racketblock
+  (class (C a b c) #:fundeps [[a t:-> c]]))
+
+…then each instance of @racket[C] with the same type for @racket[a] must also have the same type for
+@racket[c]. For example, these instances would be permitted together:
+
+@(racketblock
+  (instance (C Integer Unit String))
+  (instance (C Integer Bool String)))
+
+…but these instances would not:
+
+@(racketblock
+  (instance (C Integer Unit String))
+  (instance (C Integer Bool Double)))
+
+Restriction of this sort is useful mostly because the knowledge that a class will be used this way
+allows the typechecker to perform better type inference. Without a functional dependency, use of a
+typeclass-constrained function requires all of its parameters to be known, but with a functional
+dependency, the typechecker can solve a typeclass constraint when only a subset of the parameters are
+known.
 
 If @racket[deriving-transformer-expr] is provided, it is evaluated in the
 @tech/racket-reference{transformer environment} to obtain a @deftech{deriving transformer} for the
@@ -1299,29 +1332,18 @@ Lifts a computation from the argument monad to the constructed monad.}}
 
 @defmodule[hackett/monad/reader]
 
-@defdata[(t:ReaderT r m a) (ReaderT {r t:-> (m a)})]{
+@defclass[#:super [(t:Monad m)]
+          (t:Monad-Reader r m)
+          #:fundeps [[m -> r]]
+          [ask (m r)]
+          [local (t:forall [a] {{r t:-> r} t:-> (m a) t:-> (m a)})]
+          [reader (t:forall [a] {{r t:-> a} t:-> (m a)})]]{
 
-The @deftech{reader monad transformer}, a @tech{monad transformer} that extends a monad with a
-read-only dynamic environment. The environment can be accessed with @racket[ask] and locally modified
-with @racket[local].
+The @tech[#:key "typeclass"]{class} of @tech{monads} that support reading values from a read-only
+implicit environment. The environment can be accessed with @racket[ask] and locally modified with
+@racket[local].
 
-@(hackett-interaction
-  (run-reader-t (do [x <- ask]
-                    [y <- (lift {{x + 1} :: {x - 1} :: Nil})]
-                    (lift {{y * 2} :: {y * 3} :: Nil}))
-                10))}
-
-@defproc[(run-reader-t [x (t:ReaderT r m a)] [ctx r]) (m a)]{
-
-Runs the @tech{reader monad transformer} computation @racket[x] with the context @racket[ctx] and
-produces a computation in the argument monad.}
-
-@defproc[(run-reader [x (t:ReaderT r t:Identity a)] [ctx r]) a]{
-
-Runs the @tech{reader monad transformer} computation @racket[x] with the context @racket[ctx] and
-extracts the result.}
-
-@defthing[ask (t:forall [r m] (t:ReaderT r m r))]{
+@defmethod[ask (m r)]{
 
 A computation that fetches the value of the current dynamic environment.
 
@@ -1329,7 +1351,7 @@ A computation that fetches the value of the current dynamic environment.
   (eval:check (run-reader ask 5) 5)
   (eval:check (run-reader ask "hello") "hello"))}
 
-@defproc[(asks [f {r t:-> a}]) (t:ReaderT r m a)]{
+@defmethod[reader (t:forall [a] {{r t:-> a} t:-> (m a)})]{
 
 Produces a computation that fetches a value from the current dynamic environment, applies @racket[f]
 to it, and returns the result.
@@ -1338,44 +1360,55 @@ to it, and returns the result.
   (eval:check (run-reader (asks (+ 1)) 5) 6)
   (eval:check (run-reader (asks head) {5 :: Nil}) (Just 5)))}
 
-@defproc[(local [f {r t:-> r}] [x (t:ReaderT r m a)]) (t:ReaderT r m a)]{
+@defmethod[local (t:forall [a] {{r t:-> r} t:-> (m a) t:-> (m a)})]{
 
-Produces a computation like @racket[x], except that the environment is modified in its dynamic extent
-by applying @racket[f] to it.}
+Given a function @racket[_f] and a computation @racket[_x], produces a computation like @racket[_x],
+except that its environment is modified by applying @racket[_f] to it.}}
+
+@defthing[asks (t:forall [r m a] (t:Monad-Reader r m) t:=> {{r t:-> a} t:-> (m a)})]{
+
+An alias for @racket[reader].}
+
+@defdata[(t:Reader/T r m a) (Reader/T {r t:-> (m a)})]{
+
+The @deftech{reader monad transformer}, a @tech{monad transformer} that implements the
+@racket[t:Monad-Reader] class to add support for reading values from a read-only implicit environment
+to an existing monad.
+
+@(hackett-interaction
+  (run-reader/t (do [x <- ask]
+                    [y <- (lift {{x + 1} :: {x - 1} :: Nil})]
+                    (lift {{y * 2} :: {y * 3} :: Nil}))
+                10))}
+
+@defproc[(run-reader/t [x (t:Reader/T r m a)] [ctx r]) (m a)]{
+
+Runs the @tech{reader monad transformer} computation @racket[x] with the context @racket[ctx] and
+produces a computation in the argument monad.}
+
+@defproc[(run-reader [x (t:Reader/T r t:Identity a)] [ctx r]) a]{
+
+Runs the @tech{reader monad transformer} computation @racket[x] with the context @racket[ctx] and
+extracts the result.}
 
 @subsection[#:tag "reference-error-monad"]{Error}
 
 @defmodule[hackett/monad/error]
 
-@defdata[(t:ErrorT e m a) (ErrorT (m (t:Either e a)))]{
+@defclass[#:super [(t:Monad m)]
+          (t:Monad-Error e m)
+          #:fundeps [[m -> e]]
+          [throw (t:forall [a] {e t:-> (m a)})]
+          [catch (t:forall [a] {(m a) t:-> {e t:-> (m a)} t:-> (m a)})]]{
 
-The @deftech{error monad transformer}, a @tech{monad transformer} that extends a monad with a notion
-of failure. Failures short-circuit other computations in the monad, and they can carry information,
-usually information about what caused the failure.
+The @tech[#:key "typeclass"]{class} of @tech{monads} that support a notion of failure. Failures
+short-circuit other computations in the monad, and they can carry information, usually information
+about what caused the failure.
 
-@(hackett-interaction
-  (eval:alts (run-error-t (do (lift (println "This gets printed."))
-                              (throw "Oops!")
-                              (lift (println "Never gets here."))))
-             (unsafe-run-io!
-              (run-error-t (do (lift (println "This gets printed."))
-                               (throw "Oops!")
-                               (lift (println "Never gets here.")))))))}
+@defmethod[throw (t:forall [a] {e t:-> (m a)})]{
 
-@defproc[(run-error-t [x (t:ErrorT e m a)]) (m (t:Either e a))]{
-
-Runs the @tech{error monad transformer} computation @racket[x] and produces the possibly-aborted
-result in the argument monad.}
-
-@defproc[(run-error [x (t:ErrorT e t:Identity a)]) (t:Either e a)]{
-
-Runs the @tech{error monad transformer} computation @racket[x] and extracts the possibly-aborted
-result.}
-
-@defproc[(throw [ex e]) (t:ErrorT e m a)]{
-
-Produces a computation that raises @racket[ex] as an error, aborting the current computation (unless
-caught with @racket[catch]).
+Produces a computation that raises the given value as an error, aborting the current computation
+(unless caught with @racket[catch]).
 
 @(hackett-interaction
   (eval:check (: (run-error (pure 42)) (t:Either t:String t:Integer))
@@ -1383,18 +1416,41 @@ caught with @racket[catch]).
   (eval:check (run-error (do (throw "Ack!") (pure 42)))
               (: (Left "Ack!") (t:Either t:String t:Integer))))}
 
-@defproc[(catch [x (t:ErrorT e m a)] [handler {e t:-> (t:ErrorT e* m a)}]) (t:ErrorT e* m a)]{
+@defmethod[catch (t:forall [a] {(m a) t:-> {e -> (m a)} t:-> (m a)})]{
 
-Produces a computation like @racket[x], except any errors raised are handled via @racket[handler]
-instead of immediately aborting.
+Produces a computation like the given one, except any errors raised are handled via the given handler
+function instead of immediately aborting.
 
 @(hackett-interaction
   (eval:check (: (run-error (throw "Ack!")) (t:Either t:String t:String))
               (: (Left "Ack!") (t:Either t:String t:String)))
-  (eval:check (: (run-error (catch (throw "Ack!")
-                              (λ [str] (pure {"Caught error: " ++ str}))))
-                 (t:Either t:Unit t:String))
-              (: (Right "Caught error: Ack!") (t:Either t:Unit t:String))))}
+  (eval:check (run-error (catch (throw "Ack!")
+                           (λ [str] (pure {"Caught error: " ++ str}))))
+              (: (Right "Caught error: Ack!") (t:Either t:String t:String))))}}
+
+@defdata[(t:Error/T e m a) (Error/T (m (t:Either e a)))]{
+
+The @deftech{error monad transformer}, a @tech{monad transformer} that implements the
+@racket[t:Monad-Error] class to extend a monad with a notion of failure.
+
+@(hackett-interaction
+  (eval:alts (run-error/t (do (lift (println "This gets printed."))
+                              (throw "Oops!")
+                              (lift (println "Never gets here."))))
+             (unsafe-run-io!
+              (run-error/t (do (lift (println "This gets printed."))
+                               (throw "Oops!")
+                               (lift (println "Never gets here.")))))))}
+
+@defproc[(run-error/t [x (t:Error/T e m a)]) (m (t:Either e a))]{
+
+Runs the @tech{error monad transformer} computation @racket[x] and produces the possibly-aborted
+result in the argument monad.}
+
+@defproc[(run-error [x (t:Error/T e t:Identity a)]) (t:Either e a)]{
+
+Runs the @tech{error monad transformer} computation @racket[x] and extracts the possibly-aborted
+result.}
 
 @section[#:tag "reference-controlling-evaluation"]{Controlling Evaluation}
 

--- a/hackett-lib/hackett/monad/trans/error.rkt
+++ b/hackett-lib/hackett/monad/trans/error.rkt
@@ -1,0 +1,55 @@
+#lang hackett
+
+(require hackett/data/identity
+         hackett/monad/trans)
+
+(provide (data Error/T) run-error/t map-error/t (for-type Error) run-error throw catch)
+
+(data (Error/T e m a) (Error/T (m (Either e a))))
+
+(defn run-error/t : (forall [e m a] {(Error/T e m a) -> (m (Either e a))})
+  [[(Error/T x)] x])
+
+(defn map-error/t : (forall [e e* a b m n] {{(m (Either e a)) -> (n (Either e* b))}
+                                            -> (Error/T e m a) -> (Error/T e* n b)})
+  [[f m] (Error/T (f (run-error/t m)))])
+
+(type (Error e) (Error/T e Identity))
+
+(defn run-error : (forall [e a] {((Error e) a) -> (Either e a)})
+  [[x] (run-identity (run-error/t x))])
+
+(instance (forall [e] (MonadTrans (Error/T e)))
+  [lift {Error/T . (map Right)}])
+
+(instance (forall [e m] (Functor m) => (Functor (Error/T e m)))
+  [map (λ [f (Error/T x)] (Error/T (map (map f) x)))])
+
+(instance (forall [e m] (Monad m) => (Applicative (Error/T e m)))
+  [pure {Error/T . pure . Right}]
+  [<*> (λ [(Error/T f) (Error/T x)]
+         (Error/T (do [f* <- f]
+                      (case f*
+                        [(Right f**)
+                         {(λ [x*] {f** <$> x*}) <$> x}]
+                        [(Left e)
+                         (pure (Left e))]))))])
+
+(instance (forall [e m] (Monad m) => (Monad (Error/T e m)))
+  [join (λ [(Error/T x)]
+          (Error/T (do [x* <- x]
+                       (case x*
+                         [(Right (Error/T x**)) x**]
+                         [(Left e) (pure (Left e))]))))])
+
+(def throw : (forall [e a m] (Applicative m) => {e -> (Error/T e m a)})
+  {Error/T . pure . Left})
+
+(defn catch : (forall [e e* a m] (Monad m) =>
+                      {(Error/T e m a) -> {e -> (Error/T e* m a)} -> (Error/T e* m a)})
+  [[(Error/T x) f]
+   (Error/T (do [x* <- x]
+                (case x*
+                  [(Right x**) (pure (Right x**))]
+                  [(Left e) (case (f e)
+                              [(Error/T y) y])])))])

--- a/hackett-lib/hackett/monad/trans/reader.rkt
+++ b/hackett-lib/hackett/monad/trans/reader.rkt
@@ -1,0 +1,44 @@
+#lang hackett
+
+(require hackett/data/identity
+         hackett/monad/trans
+         hackett/monad/trans/signatures)
+
+(provide (data Reader/T) run-reader/t lift-catch/reader/t (for-type Reader) run-reader ask asks local)
+
+(data (Reader/T r m a) (Reader/T {r -> (m a)}))
+
+(defn run-reader/t : (forall [r m a] {(Reader/T r m a) -> r -> (m a)})
+  [[(Reader/T f)] f])
+
+(defn lift-catch/reader/t : (forall [e r m a] {(Catch e m a) -> (Catch e (Reader/T r m) a)})
+  [[f m h] (Reader/T (λ [r] (f (run-reader/t m r) (λ [e] (run-reader/t (h e) r)))))])
+
+(type (Reader r) (Reader/T r Identity))
+
+(defn run-reader : (forall [r a] {((Reader r) a) -> r -> a})
+  [[x r] (run-identity (run-reader/t x r))])
+
+(instance (forall [r] (MonadTrans (Reader/T r)))
+  [lift {Reader/T . const}])
+
+(instance (forall [r m] (Functor m) => (Functor (Reader/T r m)))
+  [map (λ [f (Reader/T x)] (Reader/T (λ [r] (map f (x r)))))])
+
+(instance (forall [r m] (Applicative m) => (Applicative (Reader/T r m)))
+  [pure {Reader/T . const . pure}]
+  [<*> (λ [(Reader/T f) (Reader/T x)] (Reader/T (λ [r] {(f r) <*> (x r)})))])
+
+(instance (forall [r m] (Monad m) => (Monad (Reader/T r m)))
+  [join (λ [(Reader/T x)]
+          (Reader/T (λ [r] (do [x* <- (x r)]
+                               (case x* [(Reader/T y) (y r)])))))])
+
+(def ask : (forall [r m] (Applicative m) => (Reader/T r m r))
+  (Reader/T (λ [r] (pure r))))
+
+(defn asks : (forall [r m a] (Applicative m) => {{r -> a} -> (Reader/T r m a)})
+  [[f] (Reader/T (λ [r] (pure (f r))))])
+
+(defn local : (forall [r m a] {{r -> r} -> (Reader/T r m a) -> (Reader/T r m a)})
+  [[f x] (Reader/T (λ [r] (run-reader/t x (f r))))])

--- a/hackett-lib/hackett/monad/trans/signatures.rkt
+++ b/hackett-lib/hackett/monad/trans/signatures.rkt
@@ -1,0 +1,5 @@
+#lang hackett
+
+(provide (for-type Catch))
+
+(type (Catch e m a) {(m a) -> {e -> (m a)} -> (m a)})

--- a/hackett-lib/hackett/private/adt.rkt
+++ b/hackett-lib/hackett/private/adt.rkt
@@ -8,6 +8,7 @@
                      syntax/apply-transformer
                      threading
 
+                     hackett/private/expand+elaborate
                      hackett/private/infix
                      hackett/private/prop-case-pattern-expander
                      hackett/private/util/list
@@ -276,23 +277,19 @@
 
   (define/contract (pat⇒! pat)
     (-> pat?
-        (values
-         type?                                        ; the inferred type the pattern matches against;
-         (listof (cons/c identifier? type?))          ; the types of bindings produced by the pattern;
-         (-> (listof identifier?)                     ; a function that produces a Racket `match`
-             (values syntax? (listof identifier?))))) ; pattern given a set of binding ids
+        (values type?                                 ; the inferred type the pattern matches against;
+                (listof (cons/c identifier? type?)))) ; the types of bindings produced by the pattern
     (match pat
       [(pat-var _ id)
        (let ([a^ (generate-temporary)])
-         (values #`(#%type:wobbly-var #,a^) (list (cons id #`(#%type:wobbly-var #,a^)))
-                 (match-lambda [(cons id rest) (values id rest)])))]
+         (values #`(#%type:wobbly-var #,a^) (list (cons id #`(#%type:wobbly-var #,a^)))))]
       [(pat-hole _)
        (let ([a^ (generate-temporary)])
-         (values #`(#%type:wobbly-var #,a^) '() #{values #'_ %}))]
+         (values #`(#%type:wobbly-var #,a^) '()))]
       [(pat-str _ str)
-       (values (expand-type #'String) '() #{values #`(app force- #,str) %})]
+       (values (expand-type #'String) '())]
       [(pat-int _ int)
-       (values (expand-type #'Integer) '() #{values #`(app force- #,int) %})]
+       (values (expand-type #'Integer) '())]
       [(pat-con stx con)
        (define arity (data-constructor-arity con))
        (unless (zero? arity)
@@ -315,52 +312,67 @@
            stx))
 
        (let*-values ([(τs_args τ_result) (data-constructor-args/result! con)]
-                     [(assumps mk-pats) (pats⇐! pats τs_args)])
-         (values τ_result assumps
-                 (λ (ids) (let-values ([(match-pats rest) (mk-pats ids)])
-                            (values ((data-constructor-make-match-pat con) match-pats) rest)))))]
+                     [(assumps) (pats⇐! pats τs_args)])
+         (values τ_result assumps))]
       [(pat-app outer-stx (pat-base inner-stx) _)
        (raise-syntax-error #f "expected a constructor" outer-stx inner-stx)]))
 
   (define/contract (pat⇐! pat t)
-    (-> pat? type?
-        (values (listof (cons/c identifier? type?))
-                (-> (listof identifier?) (values syntax? (listof identifier?)))))
-    (let-values ([(t_⇒ assumps mk-pat) (pat⇒! pat)])
+    (-> pat? type? (listof (cons/c identifier? type?)))
+    (let-values ([(t_⇒ assumps) (pat⇒! pat)])
       (type<:! t_⇒ t #:src (pat-base-stx pat))
-      (values assumps mk-pat)))
+      assumps))
 
-  ; Combines a list of `match` pattern constructors to properly run them against a list of identifiers
-  ; in sequence, then combine the results into a list of patterns. Used by pats⇐! and pats⇒!.
+  (define/contract (pats⇒! pats)
+    (-> (listof pat?) (values (listof type?) (listof (cons/c identifier? type?))))
+    (define-values [ts assumps]
+      (for/lists [ts assumps]
+                 ([pat (in-list pats)])
+        (pat⇒! pat)))
+    (values ts (append* assumps)))
+
+  (define/contract (pats⇐! pats ts)
+    (-> (listof pat?) (listof type?) (listof (cons/c identifier? type?)))
+    (append* (for/list ([pat (in-list pats)]
+                        [t (in-list ts)])
+               (pat⇐! pat t))))
+
+  ; Given a pattern, returns a function that produces a racket/match pattern given a list of binding
+  ; identifiers. The input to this function may provide more identifiers than the pattern actually
+  ; binds, and any leftover identifiers will be returned as the second value.
+  ;
+  ; The order in which identifiers are “consumed” by the produced function must agree with the order
+  ; in which they are returned from pat⇒! and pat⇐!.
+  (define/contract (pat->mk-match-pat pat)
+    (-> pat? (-> (listof identifier?) (values syntax? (listof identifier?))))
+    (match pat
+      [(pat-var _ _)
+       (match-lambda [(cons id rest) (values id rest)])]
+      [(pat-hole _)
+       #{values #'_ %}]
+      [(pat-str _ str)
+       #{values #`(app force- #,str) %}]
+      [(pat-int _ int)
+       #{values #`(app force- #,int) %}]
+      [(pat-con stx con)
+       (pat->mk-match-pat (pat-app stx pat '()))]
+      [(pat-app stx (pat-con cstx con) pats)
+       (let ([mk-pats (combine-pattern-constructors (map pat->mk-match-pat pats))])
+         (λ (ids) (let-values ([(match-pats rest) (mk-pats ids)])
+                    (values ((data-constructor-make-match-pat con) match-pats) rest))))]))
+
+  ; Combines a list of racket/match pattern constructors to properly run them against a list of
+  ; identifiers in sequence, then combine the results into a list of patterns. Used by
+  ; pat->mk-match-pat.
   (define/contract (combine-pattern-constructors mk-pats)
     (-> (listof (-> (listof identifier?) (values syntax? (listof identifier?))))
         (-> (listof identifier?) (values (listof syntax?) (listof identifier?))))
     (λ (ids) (for/fold ([match-pats '()]
-                        [rest ids])
+                        [rest ids]
+                        #:result (values (reverse match-pats) rest))
                        ([mk-pat (in-list mk-pats)])
                (let-values ([(match-pat rest*) (mk-pat rest)])
-                 (values (snoc match-pats match-pat) rest*)))))
-
-  (define/contract (pats⇒! pats)
-    (-> (listof pat?)
-        (values (listof type?) (listof (cons/c identifier? type?))
-                (-> (listof identifier?) (values (listof syntax?) (listof identifier?)))))
-    (define-values [ts assumps mk-pats]
-      (for/lists [ts assumps mk-pats]
-                 ([pat (in-list pats)])
-        (pat⇒! pat)))
-    (values ts (append* assumps) (combine-pattern-constructors mk-pats)))
-
-  (define/contract (pats⇐! pats ts)
-    (-> (listof pat?) (listof type?)
-        (values (listof (cons/c identifier? type?))
-                (-> (listof identifier?) (values (listof syntax?) (listof identifier?)))))
-    (define-values [assumps mk-pats]
-      (for/lists [assumps mk-pats]
-                 ([pat (in-list pats)]
-                  [t (in-list ts)])
-        (pat⇐! pat t)))
-    (values (append* assumps) (combine-pattern-constructors mk-pats)))
+                 (values (cons match-pat match-pats) rest*)))))
 
 
   ;; -------------------------------------------------------------------------------------------------
@@ -554,93 +566,130 @@
 
 (begin-for-syntax
   (define-syntax-class (case*-clause num-pats)
-    #:attributes [[pat 1] [pat.pat 1] pat.disappeared-uses body]
+    #:attributes [[pat 1] [pat.pat 1] body]
     #:description "a pattern-matching clause"
     [pattern [[p:pat ...+] body:expr]
              #:fail-unless (= (length (attribute p)) num-pats)
                            (~a "mismatch between number of patterns and number of values (expected "
                                num-pats " patterns, found " (length (attribute p)) ")")
              #:attr [pat 1] (attribute p)
-             #:attr [pat.pat 1] (attribute p.pat)
-             #:attr pat.disappeared-uses (attribute p.disappeared-uses)]))
+             #:attr [pat.pat 1] (attribute p.pat)]))
 
-(define-syntax-parser case*
-  [(_ [val:expr ...+] {~var clause (case*-clause (length (attribute val)))} ...+)
-   #:do [; Determine the type to use to unify all of the body clauses. If there is
-         ; an expected type (from τ⇐/λ!), then use that type, otherwise generate a
-         ; wobbly var that will be unified against each body type.
-         (define t_body
-           (or (get-expected this-syntax)
-               #`(#%type:wobbly-var #,(generate-temporary #'body))))
+(define-syntax case*
+  (make-elaborating-transformer
+   #:allowed-passes '[expand]
+   (syntax-parser
+     [(_ [val:expr ...+] {~var clause (case*-clause (length (attribute val)))} ...+)
+      #:do [; Determine the type to use to unify all of the body clauses. If there is
+            ; an expected type (from τ⇐/λ!), then use that type, otherwise generate a
+            ; wobbly var that will be unified against each body type.
+            (define t_body
+              (or (get-expected this-syntax)
+                  #`(#%type:wobbly-var #,(generate-temporary #'body))))
 
-         ; Infer the types of each clause and expand the bodies. Each clause has N patterns, each of
-         ; which match against a particular type, and it also has a body, which must be typechecked
-         ; as well. Additionally, inferring the pattern types produces a racket/match pattern, which
-         ; we can use to implement the untyped expression.
-         (define-values [tss_pats match-pats- bodies-]
-           (for/lists [tss_pats match-pats- bodies-]
-                      ([clause (in-list (attribute clause))]
-                       [body (in-list (attribute clause.body))]
-                       [pats (in-list (attribute clause.pat.pat))])
-             (match-let*-values
+            ; Infer the types of each clause and expand the bodies. Each clause has N patterns, each
+            ; of which match against a particular type, and it also has a body, which must be
+            ; typechecked as well. Additionally, inferring the pattern types produces a racket/match
+            ; pattern, which we can use to implement the untyped expression.
+            (define-values [tss_pats bound-idss- bodies-]
+              (for/lists [tss_pats bound-idss- bodies-]
+                         ([clause (in-list (attribute clause))]
+                          [body (in-list (attribute clause.body))]
+                          [pats (in-list (attribute clause.pat.pat))])
+                (match-let*-values
                  ([; Infer the type each pattern will match against and collect the assumptions.
-                   (ts_pats assumpss mk-match-pats)
-                   (for/lists [ts_pats assumpss mk-match-pats]
+                   (ts_pats assumpss)
+                   (for/lists [ts_pats assumpss]
                               ([pat (in-list pats)])
                      (pat⇒! pat))]
                   ; Collect the set of bindings introduced by the patterns.
                   [(assumps) (append* assumpss)]
                   ; Typecheck the body expression against the expected type.
-                  [(bound-ids- body-) (τ⇐/λ! body t_body assumps)]
-                  ; Use the bound ids to construct racket/match patterns from the case patterns.
-                  [(match-pats- (list))
-                   (for/fold ([match-pats- '()]
-                              [bound-ids- bound-ids-])
-                             ([mk-match-pat (in-list mk-match-pats)])
-                     (let-values ([(match-pat- bound-ids-*) (mk-match-pat bound-ids-)])
-                       (values (cons match-pat- match-pats-) bound-ids-*)))]
-                  ; Collect the racket/match patterns into a single, multi-pattern clause.
-                  [(match-pat-) (quasisyntax/loc clause
-                                  (#,@(reverse match-pats-)))])
-               ; Return all the results of the inference process.
-               (values ts_pats match-pat- body-))))
+                  [(bound-ids- body-) (τ⇐/λ! body t_body assumps)])
+                 ; Return all the results of the inference process.
+                 (values ts_pats bound-ids- body-))))
 
-         ; Now that we’ve inferred the types that each pattern can match against, we should infer the
-         ; types of each value being matched and ensure that all the patterns match against it. In
-         ; order to do this, we want to transpose the list of inferred pattern types so that we can
-         ; group all the types together that correspond to the same value. We also want to do the same
-         ; for the patterns themselves, though only to provide useful source location information for
-         ; type errors errors.
-         (define tss_pats-transposed (apply map list tss_pats))
-         (define patss-transposed (apply map list (attribute clause.pat)))]
-   ; Now we can iterate over the types and ensure each value has the appropriate type.
-   #:with [val- ...] (for/list ([val (in-list (attribute val))]
-                                [ts_pats (in-list tss_pats-transposed)]
-                                [pats (in-list patss-transposed)])
-                       (let ([val^ (generate-temporary)])
-                         (for-each #{type<:! %1 #`(#%type:wobbly-var #,val^) #:src %2} ts_pats pats)
-                         (τ⇐! val (apply-current-subst #`(#%type:wobbly-var #,val^)))))
+            ; Now that we’ve inferred the types that each pattern can match against, we should infer
+            ; the types of each value being matched and ensure that all the patterns match against it.
+            ; In order to do this, we want to transpose the list of inferred pattern types so that we
+            ; can group all the types together that correspond to the same value. We also want to do
+            ; the same for the patterns themselves, though only to provide useful source location
+            ; information for type errors errors.
+            (define tss_pats-transposed (apply map list tss_pats))
+            (define patss-transposed (apply map list (attribute clause.pat)))]
+      ; Now we can iterate over the types and ensure each value has the appropriate type.
+      #:with [val- ...] (for/list ([val (in-list (attribute val))]
+                                   [ts_pats (in-list tss_pats-transposed)]
+                                   [pats (in-list patss-transposed)])
+                          (let ([val^ (generate-temporary)])
+                            (for ([t_pat (in-list ts_pats)]
+                                  [pat (in-list pats)])
+                              (type<:! t_pat #`(#%type:wobbly-var #,val^) #:src pat))
+                            (τ⇐! val (apply-current-subst #`(#%type:wobbly-var #,val^)))))
 
-   #:do [; Perform exhaustiveness checking.
-         (define non-exhaust (check-exhaustiveness (attribute clause.pat.pat)
-                                                   (length (attribute val))))]
-   #:fail-when non-exhaust
-               (string-append "non-exhaustive pattern match\n  unmatched case"
-                              (if (= (length non-exhaust) 1) "" "s")
-                              ":" (string-append* (map #{string-append "\n    " (ideal->string %)}
-                                                       non-exhaust)))
+      #:do [; Perform exhaustiveness checking.
+            (define non-exhaust (check-exhaustiveness (attribute clause.pat.pat)
+                                                      (length (attribute val))))]
+      #:fail-when non-exhaust (string-append
+                               "non-exhaustive pattern match\n  unmatched case"
+                               (if (= (length non-exhaust) 1) "" "s")
+                               ":" (string-append* (map #{string-append "\n    " (ideal->string %)}
+                                                        non-exhaust)))
 
-   #:do [; The resulting type of the case expression is the type we unified each clause against.
-         (define t_result
-           (apply-current-subst t_body))]
+      #:do [; The resulting type of the case expression is the type we unified each clause against.
+            (define t_result
+              (apply-current-subst t_body))]
 
-   ; Finally, we can actually emit the result syntax, using racket/match.
-   #:with [match-pat- ...] match-pats-
-   #:with [body- ...] bodies-
-   (~> (syntax/loc this-syntax
-         (lazy- (match*- [val- ...] [match-pat- body-] ...)))
-       (attach-type t_result)
-       (syntax-property 'disappeared-use (attribute clause.pat.disappeared-uses)))])
+      ; Finally, we can actually emit the result syntax, using racket/match.
+      #:with [[bound-id- ...] ...] bound-idss-
+      #:with [body- ...] bodies-
+      (~> (syntax/loc this-syntax
+            (deferred-case* [val- ...] [[bound-id- ...] [clause.pat ...] body-] ...))
+          (attach-type t_result))])))
+
+; Since racket/match uses syntax-parameterize, which in turn uses local-expand, we need to avoid
+; expanding to `match` too early, since that will potentially force expansion of things that should be
+; deferred to elaboration. To accommodate this, this macro waits until finalization to actually expand
+; into `match`.
+;
+; (This will hopefully get less ugly once Hackett has a real core language, since a core #%case form
+; should be able to subsume this macro.)
+(define-syntax deferred-case*
+  (make-elaborating-transformer
+   (syntax-parser
+     [(head [val-:expr ...+] [[x-:id ...] [pat:pat ...] body-:expr] ...)
+      (match (syntax-local-elaborate-pass)
+        ; In 'expand or 'elaborate mode, we need to manually expand the body forms, making sure the
+        ; runtime binding are locally bound using a definition context.
+        [(or 'expand 'elaborate)
+         (let ([intdef-ctx (syntax-local-make-definition-context)])
+           (syntax-local-bind-syntaxes (append* (attribute x-)) #f intdef-ctx)
+           (with-syntax ([[[x-* ...] ...]
+                          (internal-definition-context-introduce intdef-ctx #'[[x- ...] ...])]
+                         [[body-* ...]
+                          (for/list ([body- (in-list (attribute body-))])
+                            (local-expand/defer-elaborate body- 'expression '() (list intdef-ctx)))])
+             (syntax-local-elaborate-defer
+              (syntax/loc this-syntax
+                (head [val- ...] [[x-* ...] [pat ...] body-*] ...)))))]
+
+        ; In 'finalize mode, we actually generate racket/match patterns from Hackett patterns and
+        ; expand to a use of `match` from racket/match.
+        ['finalize
+         (with-syntax ([[match-pats- ...]
+                        (for/list ([xs- (in-list (attribute x-))]
+                                   [pats (in-list (attribute pat.pat))])
+                          (match-define-values [match-pats- (list)]
+                            (for/fold ([match-pats- '()]
+                                       [xs- xs-])
+                                      ([pat (in-list pats)])
+                              (let-values ([(match-pat- xs-*) ((pat->mk-match-pat pat) xs-)])
+                                (values (cons match-pat- match-pats-) xs-*))))
+                          (reverse match-pats-))])
+           (~> (quasisyntax/loc this-syntax
+                 (lazy- #,(syntax/loc this-syntax
+                            (match*- [val- ...] [match-pats- body-] ...))))
+               (syntax-property 'disappeared-use (attribute pat.disappeared-uses))))])])))
 
 (define-syntax-parser case
   [(_ val:expr {~describe "a pattern-matching clause" [pat:pat body:expr]} ...+)

--- a/hackett-lib/hackett/private/adt.rkt
+++ b/hackett-lib/hackett/private/adt.rkt
@@ -217,7 +217,10 @@
              #:declare pat-id (local-value case-pattern-expander?)
              #:do [(define trans
                      (case-pattern-expander-transformer (attribute pat-id.local-value)))]
-             #:with :pat (local-apply-transformer trans #'pat-exp 'expression)]
+             #:with p:pat (local-apply-transformer trans #'pat-exp 'expression)
+             #:attr pat (attribute p.pat)
+             #:attr disappeared-uses (cons (syntax-local-introduce #'pat-id)
+                                           (attribute p.disappeared-uses))]
 
     [pattern {~and constructor:data-constructor-val ~!}
              #:do [(define val (attribute constructor.local-value))]
@@ -227,8 +230,8 @@
              #:attr pat (pat-app this-syntax
                                  (attribute head.pat)
                                  (attribute arg.pat))
-             #:attr disappeared-uses (cons (syntax-local-introduce #'constructor)
-                                           (append* (attribute arg.disappeared-uses)))]
+             #:attr disappeared-uses (append (attribute head.disappeared-uses)
+                                             (append* (attribute arg.disappeared-uses)))]
     [pattern {~braces a:pat constructor:data-constructor-val b:pat}
              #:do [(define val (attribute constructor.local-value))
                    (define arity (data-constructor-arity val))]

--- a/hackett-lib/hackett/private/base.rkt
+++ b/hackett-lib/hackett/private/base.rkt
@@ -12,7 +12,8 @@
          racket/stxparam
          syntax/parse/define
 
-         (for-syntax hackett/private/infix
+         (for-syntax hackett/private/expand+elaborate
+                     hackett/private/infix
                      hackett/private/typecheck
                      hackett/private/typeclass
                      hackett/private/util/list
@@ -23,7 +24,7 @@
                      τs⇔/λ! τ⇔/λ! τ⇔! τ⇐/λ! τ⇐! τ⇒/λ! τ⇒! τ⇒app! τs⇒!)
          (rename-out [#%top @%top])
          @%module-begin @%datum @%app
-         @%superclasses-key @%dictionary-placeholder @%with-dictionary #%defer-expansion
+         @%superclasses-key @%dictionary-placeholder @%with-dictionary
          define-primop define-base-type
          -> Integer Double String
          : λ1 def let letrec todo!)
@@ -42,10 +43,6 @@
 (begin-for-syntax
   ;; -------------------------------------------------------------------------------------------------
   ;; inference/checking + erasure/expansion
-
-  (define stop-ids (list #'@%dictionary-placeholder
-                         #'@%with-dictionary
-                         #'#%defer-expansion))
 
   ; The following functions perform type inference and typechecking. This process is performed by
   ; expanding expressions, which can also be seen as a type erasure pass. These functions follow a
@@ -193,9 +190,9 @@
                     [scoped-intdef-ctx (in-list scoped-intdef-ctxs)])
           (let* ([e- (let ([intdef-ctxs (if scoped-intdef-ctx
                                             (list intdef-ctx scoped-intdef-ctx)
-                                            intdef-ctx)])
+                                            (list intdef-ctx))])
                        (let loop ([e e/elab])
-                         (syntax-parse (local-expand e 'expression stop-ids intdef-ctxs)
+                         (syntax-parse (local-expand/defer-elaborate e 'expression '() intdef-ctxs)
                            #:literals [#%expression]
                            ; Expand through #%expression forms if we don’t find an inferred type
                            ; immediately and hope that the nested expression will have a type.
@@ -288,48 +285,67 @@
 
 (define-syntax-parser @%with-dictionary
   [(_ constr e)
-   #:with this #`(quote-syntax #,this-syntax)
    #:with dict-id (generate-temporary #'constr)
-   #'(λ- (dict-id)
-       (syntax-parameterize
-           ([local-class-instances
-             (let ([existing-instances (syntax-parameter-value #'local-class-instances)]
-                   [new-instances (constr->instances (quote-syntax constr) #'dict-id)])
-               (append new-instances existing-instances))])
-         e))])
+   (syntax/loc this-syntax
+     (@%with-dictionary* constr dict-id e))])
+
+(define-syntax-parser @%with-dictionary*
+  [(head constr dict-id:id e)
+   #:fail-unless (syntax-local-elaborate-pass) "not currently elaborating"
+   (match (syntax-local-elaborate-pass)
+     ['expand
+      (syntax-local-elaborate-defer
+       (quasisyntax/loc this-syntax
+         (head constr dict-id #,(local-expand/defer-elaborate #'e 'expression '()))))]
+     ['elaborate
+      (let* ([intdef-ctx (syntax-local-make-definition-context)]
+             [dict-id* (internal-definition-context-introduce intdef-ctx #'dict-id)]
+             [new-instances (constr->instances #'constr dict-id*)])
+        (syntax-local-bind-syntaxes (list #'dict-id) #f intdef-ctx)
+        (parameterize ([current-local-class-instances
+                        (append new-instances (current-local-class-instances))])
+          (syntax-local-elaborate-defer
+           (quasisyntax/loc this-syntax
+             (head constr #,dict-id*
+                   #,(local-expand/defer-elaborate #'e 'expression '() (list intdef-ctx)))))))]
+     ['finalize
+      (let ([new-instances (constr->instances #'constr #'dict-id)])
+        (parameterize ([current-local-class-instances
+                        (append new-instances (current-local-class-instances))])
+          (local-expand/defer-elaborate
+           (syntax/loc this-syntax
+             (λ- (dict-id) e))
+           'expression '())))])])
 
 (define-syntax-parser @%dictionary-placeholder
-  [(_ constr-expr src-expr)
-   #:with this #`(quote-syntax #,this-syntax)
-   #'(let-syntax-
-         ([dict-expr
-           (let*-values ([(constr) (quote-syntax constr-expr)]
-                         [(instance constrs) (lookup-instance! constr #:src (quote-syntax src-expr))]
-                         [(dict-expr) (class:instance-dict-expr instance)])
-             ; It’s possible that the dictionary itself requires dictionaries for classes with
-             ; subgoals, like (instance ∀ [a] [(Show a)] => (Show (List a)) ...). If there are not
-             ; any constraints, we need to produce a (curried) application to sub-dictionaries, which
-             ; should be recursively elaborated.
-             (make-variable-like-transformer
-              (foldr (λ (constr acc)
-                       #`(#,acc
-                          #,(quasisyntax/loc this
-                              (@%dictionary-placeholder #,constr src-expr))))
-                     dict-expr
-                     constrs)))])
-       dict-expr)])
-
-(define-syntax-parser #%defer-expansion
-  [(_ e) #'e])
+  [(_ constr src-expr)
+   #:fail-unless (syntax-local-elaborate-pass) "not currently elaborating"
+   #:fail-when (eq? (syntax-local-elaborate-pass) 'finalize) "not allowed after elaboration"
+   (match (syntax-local-elaborate-pass)
+     ['expand
+      (syntax-local-elaborate-defer this-syntax)]
+     ['elaborate
+      (let*-values ([(instance constrs) (lookup-instance! #'constr #:src #'src-expr)]
+                    [(dict-expr) (replace-stx-loc (class:instance-dict-expr instance) this-syntax)])
+        ; It’s possible that the dictionary itself requires dictionaries for classes with
+        ; subgoals, like (instance ∀ [a] [(Show a)] => (Show (List a)) ...). If there are not
+        ; any constraints, we need to produce a (curried) application to sub-dictionaries, which
+        ; should be recursively elaborated.
+        (foldr (λ (constr acc)
+                 #`(#,acc
+                    #,(quasisyntax/loc this-syntax
+                        (@%dictionary-placeholder #,constr src-expr))))
+               dict-expr
+               constrs))])])
 
 ;; ---------------------------------------------------------------------------------------------------
 
 (define-syntax-parser @%module-begin
   [(_ form ...)
-   (~> (local-expand (value-namespace-introduce
-                      (syntax/loc this-syntax
-                        (#%plain-module-begin- form ...)))
-                     'module-begin '())
+   (~> (syntax/loc this-syntax
+         (#%plain-module-begin- form ...))
+       value-namespace-introduce
+       local-expand+elaborate
        apply-current-subst-in-tooltips)])
 
 (define-syntax-parser @%datum
@@ -343,43 +359,50 @@
   [(_ . x)
    (raise-syntax-error #f "literal not supported" #'x)])
 
-(define-syntax-parser :
-  ; The #:exact option prevents : from performing context reduction. This is not normally important,
-  ; but it is required for forms that use : to ensure an expression has a particular shape in order to
-  ; interface with untyped (i.e. Racket) code, and therefore the resulting type is ignored. For
-  ; example, the def form wraps an expression in its expansion with :, but it binds the actual
-  ; identifier to a syntax transformer that attaches the type directly. Therefore, it needs to perform
-  ; context reduction itself prior to expanding to :, and it must use #:exact.
-  [(_ e {~type t:type} {~optional {~and #:exact exact?}})
-   #:with t_reduced (if (attribute exact?)
-                        #'t.expansion
-                        (type-reduce-context #'t.expansion))
-   (attach-type #`(let-values- ([() t.residual])
-                  #,(τ⇐! ((attribute t.scoped-binding-introducer) #'e) #'t_reduced))
-                #'t_reduced)])
+(define-syntax :
+  (make-trampolining-expression-transformer
+   (syntax-parser
+     ; The #:exact option prevents : from performing context reduction. This is not normally
+     ; important, but it is required for forms that use : to ensure an expression has a particular
+     ; shape in order to interface with untyped (i.e. Racket) code, and therefore the resulting type
+     ; is ignored. For example, the def form wraps an expression in its expansion with :, but it binds
+     ; the actual identifier to a syntax transformer that attaches the type directly. Therefore, it
+     ; needs to perform context reduction itself prior to expanding to :, and it must use #:exact.
+     [(_ e {~type t:type} {~optional {~and #:exact exact?}})
+      #:with t_reduced (if (attribute exact?)
+                           #'t.expansion
+                           (type-reduce-context #'t.expansion))
+      (attach-type #`(let-values- ([() t.residual])
+                                  #,(τ⇐! ((attribute t.scoped-binding-introducer) #'e) #'t_reduced))
+                   #'t_reduced)])))
 
-(define-syntax-parser λ1
-  [(_ x:id e:expr)
-   #:do [(define t (get-expected this-syntax))]
-   #:fail-unless t "no expected type, add more type annotations"
-   #:with {~or {~-> a b} {~fail (format "expected ~a, given function" (type->string t))}} t
-   #:do [(define-values [xs- e-] (τ⇐/λ! #'e #'b (list (cons #'x #'a))))]
-   #:with [x-] xs-
-   (attach-type #`(λ- (x-) #,e-) t)]
-  [(_ x:id e:expr)
-   #:with x^ (generate-temporary)
-   #:with y^ (generate-temporary)
-   #:do [(define-values [xs- e-]
-           (τ⇐/λ! #'e #'(#%type:wobbly-var y^) (list (cons #'x #'(#%type:wobbly-var x^)))))]
-   #:with [x-] xs-
-   (attach-type #`(λ- (x-) #,e-) (template (?->* (#%type:wobbly-var x^) (#%type:wobbly-var y^))))])
+(define-syntax λ1
+  (make-trampolining-expression-transformer
+   (syntax-parser
+     [(_ x:id e:expr)
+      #:do [(define t (get-expected this-syntax))]
+      #:fail-unless t "no expected type, add more type annotations"
+      #:with {~or {~-> a b} {~fail (format "expected ~a, given function" (type->string t))}} t
+      #:do [(define-values [xs- e-] (τ⇐/λ! #'e #'b (list (cons #'x #'a))))]
+      #:with [x-] xs-
+      (attach-type #`(λ- (x-) #,e-) t)]
+     [(_ x:id e:expr)
+      #:with x^ (generate-temporary)
+      #:with y^ (generate-temporary)
+      #:do [(define-values [xs- e-]
+              (τ⇐/λ! #'e #'(#%type:wobbly-var y^) (list (cons #'x #'(#%type:wobbly-var x^)))))]
+      #:with [x-] xs-
+      (attach-type #`(λ- (x-) #,e-)
+                   (template (?->* (#%type:wobbly-var x^) (#%type:wobbly-var y^))))])))
 
-(define-syntax-parser @%app
-  [(_ f:expr e:expr)
-   #:do [(define-values [f- t_f] (τ⇒! #'f))
-         (define-values [r- t_r] (τ⇒app! f- (apply-current-subst t_f) #'e
-                                         #:src this-syntax))]
-   (attach-type r- t_r #:tooltip-src this-syntax)])
+(define-syntax @%app
+  (make-trampolining-expression-transformer
+   (syntax-parser
+     [(_ f:expr e:expr)
+      #:do [(define-values [f- t_f] (τ⇒! #'f))
+            (define-values [r- t_r] (τ⇒app! f- (apply-current-subst t_f) #'e
+                                            #:src this-syntax))]
+      (attach-type r- t_r #:tooltip-src this-syntax)])))
 
 (define-syntax-parser def
   #:literals [:]
@@ -396,52 +419,62 @@
           #'(define-syntax- id (make-typed-var-transformer #'id- (quote-syntax t_reduced)))
           (attribute fixity.fixity))
        (define- id- (:/use #,((attribute t.scoped-binding-introducer) #'e) t_reduced #:exact)))]
-  [(_ id:id
-      {~optional fixity:fixity-annotation}
-      e:expr)
-   #:with x^ (generate-temporary)
-   #:with t_e #'(#%type:wobbly-var x^)
-   #:do [(match-define-values [(list id-) e-] (τ⇐/λ! #'e #'t_e (list (cons #'id #'t_e))))]
-   #:with t_gen (type-reduce-context (generalize (apply-current-subst #'t_e)))
-   #`(begin-
-       #,(indirect-infix-definition
-          #`(define-syntax- id (make-typed-var-transformer (quote-syntax #,id-) (quote-syntax t_gen)))
-          (attribute fixity.fixity))
-       (define- #,id- #,e-))])
+  [(_ id:id {~optional fixity:fixity-annotation} e:expr)
+   (if (and (eq? (syntax-local-context) 'top-level)
+            (not (syntax-local-elaborate-pass)))
+       (syntax-local-elaborate-top this-syntax)
+       (match-let*-values ([[t_e] #`(#%type:wobbly-var #,(generate-temporary))]
+                           [[(list id-) e-] (τ⇐/λ! #'e t_e (list (cons #'id t_e)))]
+                           [[t_gen] (type-reduce-context (generalize (apply-current-subst t_e)))])
+         #`(begin-
+             #,(indirect-infix-definition
+                #`(define-syntax- id (make-typed-var-transformer (quote-syntax #,id-)
+                                                                 (quote-syntax #,t_gen)))
+                (attribute fixity.fixity))
+             (define- #,id- #,e-))))])
 
 (begin-for-syntax
   (struct todo-item (full summary) #:prefab))
 
-(define-syntax-parser todo!*
-  [(_ v e ...)
-   #:do [(define type (apply-current-subst #'(#%type:wobbly-var v)))
-         (define type-str (type->string type))]
-   #:with message (string-append (source-location->prefix this-syntax)
-                                 "todo! with type "
-                                 type-str)
-   (syntax-property (syntax/loc this-syntax (error 'message))
-                    'todo (todo-item type-str type-str))])
+(define-syntax todo!*
+  (make-elaborating-transformer
+   (syntax-parser
+     [(_ v e ...)
+      (match (syntax-local-elaborate-pass)
+        [(or 'expand 'elaborate)
+         (syntax-local-elaborate-defer this-syntax)]
+        ['finalize
+         (let* ([type-str (type->string (apply-current-subst #'(#%type:wobbly-var v)))]
+                [message (string-append (source-location->prefix this-syntax)
+                                        "todo! with type "
+                                        type-str)])
+           (syntax-property (quasisyntax/loc this-syntax (error '#,message))
+                            'todo (todo-item type-str type-str)))])])))
 
-(define-syntax-parser todo!
-  [(_ e ...)
-   #:with var (generate-temporary #'t_todo!)
-   #:with contents (syntax/loc this-syntax (todo!* var e ...))
-   (attach-type (syntax/loc this-syntax (#%defer-expansion contents))
-                #'(#%type:wobbly-var var))])
+(define-syntax todo!
+  (make-elaborating-transformer
+   #:allowed-passes '[expand]
+   (syntax-parser
+     [(_ e ...)
+      #:with var (generate-temporary #'t_todo!)
+      (attach-type (syntax-local-elaborate-defer (syntax/loc this-syntax (todo!* var e ...)))
+                   #'(#%type:wobbly-var var))])))
 
-(define-syntax-parser let1
-  #:literals [:]
-  [(_ [id:id {~optional {~seq colon:: {~type t-ann:type}}} val:expr] body:expr)
-   #:do [(define-values [val- t_val]
-           (τ⇔! #'val (and~> (attribute t-ann.expansion) type-reduce-context)))
-         (match-define-values [(list id-) body- t_body]
-           (τ⇔/λ! #'body (get-expected this-syntax) (list (cons #'id t_val))))]
-   (~> (quasitemplate/loc this-syntax
-         (let-values- ([(#,id-) #,val-]
-                       {?? [() t-ann.residual]})
-           #,body-))
-       (attach-type t_body)
-       (syntax-property 'disappeared-use (and~> (attribute colon) syntax-local-introduce)))])
+(define-syntax let1
+  (make-trampolining-expression-transformer
+   (syntax-parser
+     #:literals [:]
+     [(_ [id:id {~optional {~seq colon:: {~type t-ann:type}}} val:expr] body:expr)
+      #:do [(define-values [val- t_val]
+              (τ⇔! #'val (and~> (attribute t-ann.expansion) type-reduce-context)))
+            (match-define-values [(list id-) body- t_body]
+              (τ⇔/λ! #'body (get-expected this-syntax) (list (cons #'id t_val))))]
+      (~> (quasitemplate/loc this-syntax
+                             (let-values- ([(#,id-) #,val-]
+                                           {?? [() t-ann.residual]})
+                                          #,body-))
+          (attach-type t_body)
+          (syntax-property 'disappeared-use (and~> (attribute colon) syntax-local-introduce)))])))
 
 (define-syntax-parser let
   #:literals [:]
@@ -456,49 +489,53 @@
           #,(syntax/loc this-syntax
               (let (binding-pairs ...) body))))])])
 
-(define-syntax-parser letrec
-  #:literals [:]
-  [(_ ([id:id {~optional {~seq colon:: {~type t-ann:type}}} val:expr] ...+) body:expr)
-   #:do [; First, start by grouping bindings into two sets: those with explicit type annotations, and
-         ; those without. For those without explicit type annotations, synthesize a fresh type
-         ; variable to serve as their types.
-         (define-values [ids+ts+vals/ann ids+ts+vals/unann]
-           (let-values
-               ([(ids+ts+vals/ann ids+ts+vals/unann)
-                 (for/fold ([ids+ts+vals/ann '()]
-                            [ids+ts+vals/unann '()])
-                           ([id (in-list (attribute id))]
-                            [t-ann (in-list (attribute t-ann.expansion))]
-                            [val (in-list (attribute val))])
-                   (if t-ann
-                       (values (cons (list id (type-reduce-context t-ann) val)
-                                     ids+ts+vals/ann)
-                               ids+ts+vals/unann)
-                       (let* ([t_val-id (generate-temporary)]
-                              [t_val #`(#%type:wobbly-var #,t_val-id)])
-                         (values ids+ts+vals/ann (cons (list id t_val val) ids+ts+vals/unann)))))])
-             (values (reverse ids+ts+vals/ann) (reverse ids+ts+vals/unann))))
+(define-syntax letrec
+  (make-trampolining-expression-transformer
+   (syntax-parser
+     #:literals [:]
+     [(_ ([id:id {~optional {~seq colon:: {~type t-ann:type}}} val:expr] ...+) body:expr)
+      #:do [; First, start by grouping bindings into two sets: those with explicit type annotations,
+            ; and those without. For those without explicit type annotations, synthesize a fresh type
+            ; variable to serve as their types.
+            (define-values [ids+ts+vals/ann ids+ts+vals/unann]
+              (let-values
+                  ([(ids+ts+vals/ann ids+ts+vals/unann)
+                    (for/fold ([ids+ts+vals/ann '()]
+                               [ids+ts+vals/unann '()])
+                              ([id (in-list (attribute id))]
+                               [t-ann (in-list (attribute t-ann.expansion))]
+                               [val (in-list (attribute val))])
+                      (if t-ann
+                          (values (cons (list id (type-reduce-context t-ann) val)
+                                        ids+ts+vals/ann)
+                                  ids+ts+vals/unann)
+                          (let* ([t_val-id (generate-temporary)]
+                                 [t_val #`(#%type:wobbly-var #,t_val-id)])
+                            (values ids+ts+vals/ann (cons (list id t_val val) ids+ts+vals/unann)))))])
+                (values (reverse ids+ts+vals/ann) (reverse ids+ts+vals/unann))))
 
-         ; Next, establish a dictionary mapping all bindings to their types. This will be used as a
-         ; binding context when typechecking.
-         (define ids+ts (map #{cons (first %) (second %)} (append ids+ts+vals/ann ids+ts+vals/unann)))
-         ; We also need to produce a mapping of expressions to their annotations, plus the body. This
-         ; will be handed off to the expander to be typechecked.
-         (define es+ts
-           (snoc (map #{cons (third %) (second %)} (append ids+ts+vals/ann ids+ts+vals/unann))
-                 (cons #'body (get-expected this-syntax))))
+            ; Next, establish a dictionary mapping all bindings to their types. This will be used as a
+            ; binding context when typechecking.
+            (define ids+ts (map #{cons (first %) (second %)}
+                                (append ids+ts+vals/ann ids+ts+vals/unann)))
+            ; We also need to produce a mapping of expressions to their annotations, plus the body.
+            ; This will be handed off to the expander to be typechecked.
+            (define es+ts
+              (snoc (map #{cons (third %) (second %)} (append ids+ts+vals/ann ids+ts+vals/unann))
+                    (cons #'body (get-expected this-syntax))))
 
-         ; With the setup out of the way, we can now call τs⇔/λ! to perform the actual typechecking.
-         (match-define-values [ids- (list vals- ... body-) (list _ ... t_body)]
-           (τs⇔/λ! es+ts ids+ts))]
+            ; With the setup out of the way, we can now call τs⇔/λ! to perform the actual
+            ; typechecking.
+            (match-define-values [ids- (list vals- ... body-) (list _ ... t_body)]
+              (τs⇔/λ! es+ts ids+ts))]
 
-   ; Finally, expand to the runtime value.
-   #:with [id- ...] ids-
-   #:with [val- ...] vals-
-   (~> (quasitemplate/loc this-syntax
-         (letrec-values ([(id-) val-] ...
-                         {?? [() t-ann.residual]} ...)
-           #,body-))
-       (attach-type t_body)
-       (syntax-property 'disappeared-use
-                        (map syntax-local-introduce (filter values (attribute colon)))))])
+      ; Finally, expand to the runtime value.
+      #:with [id- ...] ids-
+      #:with [val- ...] vals-
+      (~> (quasitemplate/loc this-syntax
+                             (letrec-values ([(id-) val-] ...
+                                             {?? [() t-ann.residual]} ...)
+                               #,body-))
+          (attach-type t_body)
+          (syntax-property 'disappeared-use
+                           (map syntax-local-introduce (filter values (attribute colon)))))])))

--- a/hackett-lib/hackett/private/class.rkt
+++ b/hackett-lib/hackett/private/class.rkt
@@ -2,8 +2,9 @@
 
 (require racket/require hackett/private/type-reqprov hackett/private/util/require
 
-         (for-syntax (multi-in racket [base format list syntax])
+         (for-syntax (multi-in racket [base format list match set string syntax])
                      (multi-in syntax/parse [class/local-value experimental/template])
+                     syntax/id-set
                      syntax/id-table
                      threading)
          (postfix-in - (combine-in racket/base
@@ -13,7 +14,7 @@
          (for-syntax hackett/private/infix)
          (except-in hackett/private/base @%app)
          (only-in (unmangle-types-in #:no-introduce (only-types-in hackett/private/kernel))
-                  ∀ => [#%app @%app]))
+                  ∀ => -> [#%app @%app]))
 
 (provide (for-syntax class-id)
          class instance derive-instance)
@@ -29,9 +30,13 @@
                    "class is not derivable"]))
 
 (define-syntax-parser class
-  #:literals [: => let-values #%plain-app]
+  #:literals [: => -> let-values #%plain-app]
   [(_ {~optional {~seq {~type constr} ... {~type =>/use:=>}} #:defaults ([[constr 1] '()])}
       {~type (name:id var-id:id ...)}
+      {~optional {~seq #:fundeps {~type [[{~and {~not ->} fundep-lhs:id} ...+
+                                          ->/use:-> {~and {~not ->} fundep-rhs:id} ...+]
+                                         ...]}}
+                 #:defaults ([[fundep-lhs 2] '()] [[fundep-rhs 2] '()] [[->/use 1] '()])}
       [method-id:id
        {~or {~once {~seq {~and : {~var :/use}} {~type bare-t}}}
             {~optional fixity:fixity-annotation}}
@@ -40,6 +45,13 @@
       ...
       {~optional {~seq #:deriving-transformer deriving-transformer:expr}
                  #:defaults ([deriving-transformer #'#f])})
+   #:fail-when (for*/or ([fundep-vars (in-sequences (in-list (attribute fundep-lhs))
+                                                    (in-list (attribute fundep-rhs)))]
+                         [fundep-var (in-list fundep-vars)])
+                 (and (not (member fundep-var (attribute var-id) bound-identifier=?))
+                      fundep-var))
+               "non-class variable in functional dependency specification"
+
    ; The methods in a class’s method table should *not* be quantified. That is, in this class:
    ;
    ;    (class (Show a)
@@ -51,8 +63,10 @@
    ; We also want to expand superclass constraints in the same context so that the same variable is
    ; bound in both situations.
    #:do [(define t-intdef-ctx (syntax-local-make-definition-context))]
-   #:with [var-id- ...] (map #{internal-definition-context-introduce t-intdef-ctx %}
-                             (attribute var-id))
+   #:with [[var-id- ...] [[fundep-lhs- ...] [fundep-rhs- ...]] ...]
+          (internal-definition-context-introduce
+           t-intdef-ctx
+           #'[[var-id ...] [[fundep-lhs ...] [fundep-rhs ...]] ...])
    #:do [(syntax-local-bind-syntaxes (attribute var-id) #f t-intdef-ctx)]
 
    #:with [(~var method-t (type t-intdef-ctx)) ...] (attribute bare-t)
@@ -84,20 +98,25 @@
                 fixity))
           {?? (def method-default-id- : quantified-t #:exact method-default-impl)} ...
           (define-syntax- name
-            (class:info (list #'var-id- ...)
-                        (make-immutable-free-id-table
-                         (list (cons #'method-id (quote-syntax method-t.expansion)) ...))
-                        (make-immutable-free-id-table
-                         (list {?? (cons #'method-id #'method-default-id-)} ...))
-                        (list (quote-syntax super-constr.expansion) ...)
-                        deriving-transformer))))
-       (syntax-property 'disappeared-binding
-                        (~>> (attribute var-id)
-                             (map (λ~>> (internal-definition-context-introduce t-intdef-ctx)
-                                        syntax-local-introduce))))
-       (syntax-property 'disappeared-use (map syntax-local-introduce
-                                              (filter values (cons (attribute =>/use)
-                                                                   (attribute :/use))))))])
+            (make-class:info (list #'var-id- ...)
+                             (make-immutable-free-id-table
+                              (list (cons #'method-id (quote-syntax method-t.expansion)) ...))
+                             (make-immutable-free-id-table
+                              (list {?? (cons #'method-id #'method-default-id-)} ...))
+                             (list (quote-syntax super-constr.expansion) ...)
+                             (set (functional-dependency
+                                   (immutable-free-id-set (list (quote-syntax fundep-lhs-) ...))
+                                   (immutable-free-id-set (list (quote-syntax fundep-rhs-) ...)))
+                                  ...)
+                             deriving-transformer))))
+       (syntax-property 'disappeared-binding (map syntax-local-introduce (attribute var-id-)))
+       (syntax-property 'disappeared-use
+                        (map syntax-local-introduce
+                             (filter values (cons (attribute =>/use)
+                                                  (append (attribute :/use)
+                                                          (attribute ->/use)
+                                                          (append* (attribute fundep-lhs-))
+                                                          (append* (attribute fundep-rhs-))))))))])
 
 (begin-for-syntax
   (define-syntax-class instance-head
@@ -134,11 +153,36 @@
                     #'head-stx)
                (~a "wrong number of parameters for class ‘" (syntax-e #'class) "’; expected "
                    (length (class:info-vars class-info)) ", given " (length (attribute bare-t)))
+
+   ; Expand each provided subgoal and type in the instance head in a context where the various type
+   ; variables are bound.
+   #:do [(define t-intdef-ctx (syntax-local-make-definition-context))]
+   #:with [var-id- ...] (map #{internal-definition-context-introduce t-intdef-ctx %}
+                             (attribute var-id))
+   #:do [(syntax-local-bind-syntaxes (attribute var-id) #f t-intdef-ctx)]
+   #:with [(~var constr- (type t-intdef-ctx)) ...] (attribute constr)
+   #:with [(~var bare-t- (type t-intdef-ctx)) ...] (attribute bare-t)
+
+   ; Reduce the instance context, and include the instance currently being defined as a tautological
+   ; constraint to eliminate silly things like (instance (forall [a] (Eq (X a)) => (Eq (X a))) ....).
+   #:with (~var this-instance-constr (type t-intdef-ctx)) #'(@%app class bare-t-.expansion ...)
+   #:with [constr-/reduced ...] (reduce-context
+                                 (attribute constr-.expansion)
+                                 #:extra-tautological-constrs (list #'this-instance-constr.expansion))
+
+   ; Check that the instance is not overlapping.
+   #:do [(define overlapping-instances
+           (lookup-overlapping-instances class-info (attribute bare-t-.expansion)))]
+   #:fail-unless (empty? overlapping-instances)
+                 (let ([s? (if (> (length overlapping-instances) 1) "s" "")])
+                   (~a "instance overlaps with previously-declared instance" s? "\n"
+                       "  instance" s? ":\n    "
+                       (string-join (map class:instance->string overlapping-instances)
+                                    "\n    ")))
    
    ; Ensure all the provided methods belong to the class being implemented and ensure that none of the
    ; non-optional methods are unimplemented.
-   #:do [(define class-info (attribute class.local-value))
-         (define method-table (class:info-method-table class-info))
+   #:do [(define method-table (class:info-method-table class-info))
          (define default-methods (class:info-default-methods class-info))
          
          (define all-method-ids (free-id-table-keys method-table))
@@ -153,22 +197,6 @@
                (~a "not a method of class ‘" (syntax-e #'class) "’")
    #:fail-when (and (not (empty? missing-methods)) #'class)
                (~a "missing implementation of ‘" (syntax-e (first missing-methods)) "’")
-
-   ; Calculate the expected type of each method. First, we have to expand each provided subgoal and
-   ; type in the instance head in a context where the various type variables are bound.
-   #:do [(define t-intdef-ctx (syntax-local-make-definition-context))]
-   #:with [var-id- ...] (map #{internal-definition-context-introduce t-intdef-ctx %}
-                             (attribute var-id))
-   #:do [(syntax-local-bind-syntaxes (attribute var-id) #f t-intdef-ctx)]
-   #:with [(~var constr- (type t-intdef-ctx)) ...] (attribute constr)
-   #:with [(~var bare-t- (type t-intdef-ctx)) ...] (attribute bare-t)
-
-   ; Reduce the instance context, and include the instance currently being defined as a tautological
-   ; constraint to eliminate silly things like (instance (forall [a] (Eq (X a)) => (Eq (X a))) ....).
-   #:with (~var this-instance-constr (type t-intdef-ctx)) #'(@%app class bare-t-.expansion ...)
-   #:with [constr-/reduced ...] (reduce-context
-                                 (attribute constr-.expansion)
-                                 #:extra-tautological-constrs (list #'this-instance-constr.expansion))
 
    ; With the types actually expanded, we need to skolemize them for the pupose of typechecking
    ; method implementations.
@@ -208,11 +236,11 @@
            (define-values [] bare-t-.residual) ...
            (begin-for-syntax-
              (register-global-class-instance!
-              (class:instance (syntax-local-value #'class)
+              (class:instance (quote-syntax class)
                               (list (quote-syntax var-id-) ...)
                               (list (quote-syntax constr-/reduced) ...)
                               (list (quote-syntax bare-t-.expansion) ...)
-                              #'dict-id-)))
+                              (quote-syntax dict-id-))))
            ; The defined dict-id- might appear in the expansion of :/instance-dictionary, since it
            ; performs dictionary elaboration. At the top level, this can cause problems, since
            ; recursive/self-referential definitions are complicated. We can perform a sort of “forward

--- a/hackett-lib/hackett/private/expand+elaborate.rkt
+++ b/hackett-lib/hackett/private/expand+elaborate.rkt
@@ -1,0 +1,211 @@
+#lang racket/base
+
+; This module implements Hackett’s multi-pass macroexpansion performed as part of elaboration. It does
+; not actually implement any of the logic used to solve constraints; that functionality is implemented
+; by other macros that cooperate with the elaborating expander.
+;
+; When a Hackett module expands, it is expanded in three passes:
+;
+;   1. First, an initial expansion pass expands macros that do not require elaboration. Macros that
+;      require elaboration can request their expansion be deferred by expanding to a use of
+;      (syntax-local-elaborate-defer-id).
+;
+;   2. Once the initial expansion pass completes, the expander begins the process of elaboration. All
+;      macros that requested deferred expansion are re-expanded. If the macro can make progress, it
+;      calls syntax-local-elaborate-did-make-progress!. If it still requires additional information
+;      (which might be gathered while expanding other deferred macros), it calls
+;      syntax-local-elaborate-did-defer! and expands again to a use of
+;      (syntax-local-elaborate-defer-id).
+;
+;      After performing expansion, the elaborator checks whether or not any macros called
+;      syntax-local-elaborate-did-make-progress! and syntax-local-elaborate-did-defer! during
+;      elaboration. If both functions were called, the expander makes another elaboration pass.
+;      Otherwise, elaboration is complete.
+;
+;   3. Finally, the elaborator performs a finalization pass. Macros cannot request to be deferred
+;      during this pass, so they must either expand or raise an error.
+;
+; The reason for this complicated expansion process is that certain forms may wish to consume type
+; information, and others may constrain type information. The most straightforward example of this
+; behavior involves typeclasses: typeclasses require dictionary elaboration, and picking the
+; appropriate dictionary requires fully-solved type information, but solving some constraints (that
+; is, constraints with functional dependencies) may force some solver variables to unify. So we need
+; to run the solver until we reach a fixpoint.
+
+(require (for-template racket/base)
+         racket/contract
+         racket/format
+         racket/list
+         racket/match
+         racket/syntax
+         syntax/parse
+
+         hackett/private/util/stx)
+
+(provide (contract-out [syntax-local-elaborate-defer
+                        (->* [syntax?] [#:did-defer!? any/c] syntax?)]
+                       [local-expand+elaborate
+                        (->* [syntax?] [(listof internal-definition-context?)] syntax?)]
+                       [local-expand/defer-elaborate
+                        (->* [syntax?
+                              (or/c 'expression 'top-level 'module 'module-begin list?)
+                              (listof identifier?)]
+                             [(listof internal-definition-context?)]
+                             syntax?)]
+                       [make-elaborating-transformer
+                        (->* [(-> syntax? syntax?)]
+                             [#:allowed-passes (non-empty-listof elaborate-pass?)]
+                             (-> syntax? syntax?))]
+                       [syntax-local-elaborate-top
+                        (-> syntax? syntax?)])
+         elaborate-pass?
+         syntax-local-elaborate-pass
+         syntax-local-elaborating-with-defers?
+         syntax-local-elaborate-defer-id
+         syntax-local-elaborate-did-make-progress!
+         syntax-local-elaborate-did-defer!)
+
+(define elaborate-passes '(expand elaborate finalize))
+(define (elaborate-pass? v) (and (memq v elaborate-passes) #t))
+(define (elaboration-pass->string v)
+  (match v
+    ['expand "initial expansion"]
+    ['elaborate "elaboration"]
+    ['finalize "finalization"]))
+
+(define current-syntax-elaborate-pass (make-parameter #f))
+(define current-elaborate-did-make-progress? (make-parameter #f))
+(define current-elaborate-did-defer? (make-parameter #f))
+(define current-elaborate-defer-id (make-parameter #f))
+
+(define (syntax-local-elaborate-pass) (current-syntax-elaborate-pass))
+(define (syntax-local-elaborating-with-defers?)
+  (memq (current-syntax-elaborate-pass) '(expand elaborate)))
+
+(define (assert-elaborating! who [allowed-passes '(elaborate)])
+  (unless (memq (current-syntax-elaborate-pass) allowed-passes)
+    (raise-arguments-error who "not currently elaborating")))
+
+(define (syntax-local-elaborate-defer-id #:did-defer!? [did-defer!? #f])
+  (assert-elaborating! 'syntax-local-elaborate-defer-id '(expand elaborate))
+  (when (and did-defer!? (eq? (current-syntax-elaborate-pass) 'elaborate))
+    (syntax-local-elaborate-did-defer!))
+  (current-elaborate-defer-id))
+
+(define (syntax-local-elaborate-defer stx #:did-defer!? [did-defer!? #f])
+  (assert-elaborating! 'syntax-local-elaborate-defer '(expand elaborate))
+  (quasisyntax/loc stx
+    (#,(replace-stx-loc (syntax-local-elaborate-defer-id #:did-defer!? did-defer!?) stx) #,stx)))
+
+(define (syntax-local-elaborate-did-make-progress!)
+  (assert-elaborating! 'syntax-local-elaborate-did-make-progress!)
+  (current-elaborate-did-make-progress? #t))
+
+(define (syntax-local-elaborate-did-defer!)
+  (assert-elaborating! 'syntax-local-elaborate-did-defer!)
+  (current-elaborate-did-defer? #t))
+
+(define no-op-transformer (syntax-parser [(_ e) #'e]))
+
+(define (local-expand+elaborate stx [intdef-ctxs '()])
+  (define expand-context (syntax-local-context))
+
+  (unless (or (eq? expand-context 'top-level)
+              (eq? expand-context 'module-begin))
+    (raise-arguments-error 'local-expand+elaborate "not in top level or module begin context"))
+  (when (current-syntax-elaborate-pass)
+    (raise-arguments-error 'local-expand+elaborate "already elaborating"))
+
+  (let* ([intdef-ctx (syntax-local-make-definition-context #f #f)]
+         [intdef-ctxs (cons intdef-ctx intdef-ctxs)])
+
+    ; Each expansion pass needs a fresh defer binding so that subsequent expansions will expand macros
+    ; deferred in the previous pass. By binding it to #%expression but putting it in the stop list
+    ; during the expansion pass it’s introduced, it will be harmlessly expanded on subsequent passes,
+    ; but stopped on for the current pass.
+    (define (generate-defer-id)
+      (let ([defer-id (generate-temporary '#%defer)])
+        (syntax-local-bind-syntaxes (list (syntax-local-identifier-as-binding
+                                           (syntax-local-introduce defer-id)))
+                                    #'no-op-transformer
+                                    intdef-ctx)
+        (internal-definition-context-introduce intdef-ctx defer-id)))
+
+    (define (expand stx)
+      (let ([defer-id (generate-defer-id)])
+        (parameterize ([current-syntax-elaborate-pass 'expand]
+                       [current-elaborate-defer-id defer-id])
+          (local-expand stx expand-context (list #'module* defer-id) intdef-ctxs
+                        #:extend-stop-ids? #f))))
+
+    (define (elaborate stx)
+      (let ([defer-id (generate-defer-id)])
+        (parameterize ([current-syntax-elaborate-pass 'elaborate]
+                       [current-elaborate-did-make-progress? #f]
+                       [current-elaborate-did-defer? #f]
+                       [current-elaborate-defer-id defer-id])
+          (values (local-expand stx expand-context (list #'module* defer-id) intdef-ctxs
+                                #:extend-stop-ids? #f)
+                  (current-elaborate-did-make-progress?)
+                  (current-elaborate-did-defer?)))))
+
+    (define (finalize stx)
+      (parameterize ([current-syntax-elaborate-pass 'finalize])
+        (local-expand stx expand-context (list #'module*) intdef-ctxs)))
+
+    (let loop ([stx (expand stx)])
+      (let-values ([[stx* did-make-progress? did-defer?] (elaborate stx)])
+        (if (and did-make-progress? did-defer?)
+            (loop stx*)
+            (finalize stx*))))))
+
+(define (local-expand/defer-elaborate stx context stop-list [intdef-ctxs '()])
+  (let ([stop-list* (if (syntax-local-elaborating-with-defers?)
+                        (cons (syntax-local-elaborate-defer-id) stop-list)
+                        stop-list)])
+    (local-expand stx context (cons #'module* stop-list*) intdef-ctxs #:extend-stop-ids? #f)))
+
+(define (make-elaborating-transformer #:allowed-passes [allowed-passes elaborate-passes] proc)
+  ; Trampoline to get into an expression context. This helps to avoid “not currently elaborating”
+  ; failures triggered by partial expansion that could be trivially avoided by waiting a little bit
+  ; longer to be expanded (which is relevant when expanding at the top level).
+  (make-trampolining-expression-transformer
+   (lambda (stx)
+     (let ([allowed-passes (remove-duplicates allowed-passes eq?)]
+           [this-pass (syntax-local-elaborate-pass)])
+       (unless this-pass
+         (raise-syntax-error #f "not currently elaborating" stx))
+
+       (unless (memq this-pass allowed-passes)
+         (raise-syntax-error
+          #f
+          (match allowed-passes
+            [(list _ _)
+             (~a "not allowed during " (elaboration-pass->string this-pass) " pass")]
+            [(list allowed-pass)
+             (~a "only allowed during " (elaboration-pass->string allowed-pass) " pass")])
+          stx))
+
+       (proc stx)))))
+
+;; ---------------------------------------------------------------------------------------------------
+
+; When expanding at the top level, we have to be especially careful about the order of expansion,
+; since Racket needs to interleave expansion and evaluation of forms within a `begin` form. Therefore,
+; Hackett’s #%top-interaction performs partial expansion prior to performing elaboration, but in rare
+; cases, that partial expansion is the wrong thing. In those situations, macros can use
+; syntax-local-elaborate-top to request that #%top-interaction switch from partial expansion to
+; elaboration earlier than it otherwise would.
+
+(module elaborate-top-transformer racket/base
+  (require (for-syntax racket/base))
+  (provide #%elaborate-top)
+  (define-syntax (#%elaborate-top stx)
+    (raise-syntax-error #f "not at top level" stx)))
+(require (for-template 'elaborate-top-transformer))
+
+(define (syntax-local-elaborate-top stx)
+  (unless (eq? (syntax-local-context) 'top-level)
+    (raise-arguments-error 'syntax-local-elaborate-top "not in top level context"))
+  (quasisyntax/loc stx
+    (#,(replace-stx-loc #'#%elaborate-top stx) #,stx)))

--- a/hackett-lib/hackett/private/prim/base.rkt
+++ b/hackett-lib/hackett/private/prim/base.rkt
@@ -252,6 +252,9 @@
   [map (λ* [[f {y :: ys}] {(f y) :: (map f ys)}]
            [[_ Nil      ] Nil])])
 
+(instance (forall [r] (Functor (-> r)))
+  [map .])
+
 (instance (Functor IO)
   [map (λ [f (IO mx)]
          (IO (λ [rw]
@@ -285,6 +288,10 @@
 (instance (Applicative List)
   [pure (λ [x] {x :: Nil})]
   [<*> ap])
+
+(instance (forall [r] (Applicative (-> r)))
+  [pure const]
+  [<*> (λ [f g x] (f x (g x)))])
 
 (instance (Applicative IO)
   [pure (λ [x] (IO (λ [rw] (Tuple rw x))))]
@@ -335,6 +342,10 @@
   [join (λ* [[{{z :: zs} :: yss}] {z :: (join {zs :: yss})}]
             [[{Nil       :: yss}] (join yss)]
             [[Nil               ] Nil])])
+
+(instance (forall [r] (Monad (-> r)))
+  [join (λ [f x] (f x x))]
+  [=<< (λ [f g x] (f (g x) x))])
 
 (instance (Monad IO)
   [join (λ [(IO outer)]

--- a/hackett-lib/hackett/private/toplevel.rkt
+++ b/hackett-lib/hackett/private/toplevel.rkt
@@ -138,4 +138,14 @@
                        [(e-/show) (τ⇐! (quasisyntax/loc this-syntax
                                          (@%app show #,e-))
                                        (expand-type #'String))])
-     #`(repl-result (force #,e-/show) '#,(type->string (apply-current-subst τ_e))))])
+     #`(repl-result (force #,e-/show) (type-string #,τ_e)))])
+
+(define-syntax type-string
+  (make-elaborating-transformer
+   (syntax-parser
+     [(_ t)
+      (match (syntax-local-elaborate-pass)
+        [(or 'expand 'elaborate)
+         (syntax-local-elaborate-defer this-syntax)]
+        ['finalize
+         #`'#,(type->string (apply-current-subst #'t))])])))

--- a/hackett-lib/hackett/private/toplevel.rkt
+++ b/hackett-lib/hackett/private/toplevel.rkt
@@ -1,4 +1,4 @@
-#lang curly-fn racket/base
+#lang racket/base
 
 ; This module implements #%top-interaction for the Hackett REPL. It does some tricks to make Hackett
 ; forms cooperate more nicely with the top level while still being able to do things like print the
@@ -58,16 +58,25 @@
 ; eval-syntax in the current namespace instead of yielding control to the expander. That avoids the
 ; need to trampoline, but it isn’t possible to use during the extent of #%top-interaction’s expansion,
 ; since we are at phase 1, but the forms need to be evaluated at phase 0.
+;
+; The story is complicated slightly further by the additional need to perform Hackett’s dictionary
+; elaboration passes, even on parts of the form that aren’t relevant for printing type information.
+; Since elaboration involves complete expansion, the aforementioned trampolining must be formed prior
+; to elaboration. Once we discover a non-begin form, we wrap it in a form that will perform
+; elaboration.
 
 (require (for-syntax racket/base
                      racket/match
                      syntax/kerncase
                      threading
 
-                     hackett/private/typecheck)
+                     hackett/private/expand+elaborate
+                     hackett/private/typecheck
+                     hackett/private/util/stx)
          racket/promise
          syntax/parse/define
 
+         (submod hackett/private/expand+elaborate elaborate-top-transformer)
          hackett/private/type-reqprov
          (only-in hackett/private/base τ⇒! τ⇐!)
          (only-in (unmangle-types-in #:no-introduce hackett/private/kernel) String)
@@ -87,28 +96,46 @@
   [(define (write-proc result port mode)
      (fprintf port ": ~a" (type-result-type result)))])
 
-(define-simple-macro (@%top-interaction . form)
-  #:with form* (value-namespace-introduce #'form)
-  (@%top-interaction* . form*))
-
-(define-syntax-parser @%top-interaction*
-  [(_ . (#:type ~! expr:expr))
-   (match-let-values ([(_ τ_e) (τ⇒! #'expr)])
-     #`(type-result '#,(type->string (apply-current-subst τ_e))))]
+(define-syntax-parser @%top-interaction
   [(_ . form)
-   (syntax-parse (local-expand #'form 'top-level (kernel-form-identifier-list))
-     #:context this-syntax
-     #:literal-sets [kernel-literals]
-     [({~or #%require begin-for-syntax define-syntaxes define-values} . _)
-      this-syntax]
-     [(begin)
-      this-syntax]
-     [(begin form ... form*)
-      (syntax/loc this-syntax
-        (begin form ... (@%top-interaction* . form*)))]
-     [expr
-      (match-let*-values ([(e- τ_e) (τ⇒! #'expr)]
-                          [(e-/show) (τ⇐! (quasisyntax/loc this-syntax
-                                            (@%app show #,e-))
-                                          (expand-type #'String))])
-        #`(repl-result (force #,e-/show) '#,(type->string (apply-current-subst τ_e))))])])
+   (syntax-parse (value-namespace-introduce #'form)
+     [(#:type ~! expr:expr)
+      #'(infer+print-type expr)]
+     [form*
+      #'(infer+elaborate+print-value+type form*)])])
+
+(define-syntax-parser infer+print-type
+  [(_ expr:expr)
+   (match-let-values ([(_ τ_e) (τ⇒! #'expr)])
+     #`(type-result '#,(type->string (apply-current-subst τ_e))))])
+
+(define-syntax infer+elaborate+print-value+type
+  (let ([stops (cons #'#%elaborate-top (kernel-form-identifier-list))])
+    (syntax-parser
+      [(_ form)
+       (syntax-parse (local-expand #'form 'top-level stops)
+         #:context this-syntax
+         #:literal-sets [kernel-literals]
+         #:literals [#%elaborate-top]
+         [{~or (begin)
+               ({~or #%require begin-for-syntax define-syntaxes define-values} . _)}
+          #`(elaborate #,this-syntax)]
+         [(begin form ... form*)
+          (syntax/loc this-syntax
+            (begin (elaborate form) ... (infer+elaborate+print-value+type form*)))]
+         [(#%elaborate-top form)
+          #'(elaborate form)]
+         [expr
+          #'(elaborate (infer+print-value+type expr))])])))
+
+(define-syntax-parser elaborate
+  [(_ form)
+   (local-expand+elaborate #'form)])
+
+(define-syntax-parser infer+print-value+type
+  [(_ expr:expr)
+   (match-let*-values ([(e- τ_e) (τ⇒! #'expr)]
+                       [(e-/show) (τ⇐! (quasisyntax/loc this-syntax
+                                         (@%app show #,e-))
+                                       (expand-type #'String))])
+     #`(repl-result (force #,e-/show) '#,(type->string (apply-current-subst τ_e))))])

--- a/hackett-lib/hackett/private/typeclass.rkt
+++ b/hackett-lib/hackett/private/typeclass.rkt
@@ -12,7 +12,6 @@
          racket/list
          racket/match
          racket/format
-         racket/stxparam-exptime
          syntax/parse
          syntax/parse/class/local-value
          syntax/id-table
@@ -30,9 +29,10 @@
                                                [subgoals (listof constr?)]
                                                [ts (listof (and/c type? type-mono?))]
                                                [dict-expr syntax?])])
-         register-global-class-instance! constr->instances lookup-instance!
+         register-global-class-instance! current-local-class-instances
+         constr->instances lookup-instance!
          reduce-context type-reduce-context
-         (for-template local-class-instances @%superclasses-key))
+         (for-template @%superclasses-key))
 
 ;; ---------------------------------------------------------------------------------------------------
 ;; instance contexts
@@ -61,15 +61,13 @@
   (-> class:instance? void?)
   (gvector-add! global-class-instances instance))
 
-(module local-instances-stxparam racket/base
-  (require (for-syntax racket/base) racket/stxparam)
-  (provide local-class-instances)
-  (define-syntax-parameter local-class-instances '()))
-(require (for-template 'local-instances-stxparam))
+(define/contract current-local-class-instances
+  (parameter/c (listof class:instance?))
+  (make-parameter '()))
 
 (define/contract (current-class-instances)
   (-> (listof class:instance?))
-  (append (syntax-parameter-value #'local-class-instances)
+  (append (current-local-class-instances)
           (gvector->list global-class-instances)))
 
 (define (current-instances-of-class class)

--- a/hackett-lib/hackett/private/typeclass.rkt
+++ b/hackett-lib/hackett/private/typeclass.rkt
@@ -9,35 +9,60 @@
 
          data/gvector
          racket/contract
+         racket/format
          racket/list
          racket/match
-         racket/format
+         racket/set
+         racket/struct
+         syntax/id-set
+         syntax/id-table
          syntax/parse
          syntax/parse/class/local-value
-         syntax/id-table
 
          hackett/private/typecheck
+         hackett/private/util/contract
          hackett/private/util/stx)
 
-(provide (contract-out [struct class:info ([vars (listof identifier?)]
-                                           [method-table immutable-free-id-table?]
-                                           [default-methods immutable-free-id-table?]
-                                           [superclasses (listof constr?)]
-                                           [deriving-transformer (or/c (-> syntax? syntax?) #f)])]
-                       [struct class:instance ([class class:info?]
-                                               [vars (listof identifier?)]
-                                               [subgoals (listof constr?)]
-                                               [ts (listof (and/c type? type-mono?))]
-                                               [dict-expr syntax?])])
+(provide (contract-out
+          [struct functional-dependency ([determiners immutable-free-id-set?]
+                                         [determined immutable-free-id-set?])]
+          [struct class:info ([vars (listof identifier?)]
+                              [method-table immutable-free-id-table?]
+                              [default-methods immutable-free-id-table?]
+                              [superclasses (listof constr?)]
+                              [functional-dependencies (immutable-set/c functional-dependency?)]
+                              [candidate-keys (immutable-set/c immutable-free-id-set?)]
+                              [deriving-transformer (or/c (-> syntax? syntax?) #f)])]
+          [struct class:instance ([class-id identifier?]
+                                  [vars (listof identifier?)]
+                                  [subgoals (listof constr?)]
+                                  [ts (listof (and/c type? type-mono?))]
+                                  [dict-expr syntax?])])
+         make-class:info class:instance->string
          register-global-class-instance! current-local-class-instances
-         constr->instances lookup-instance!
+         constr->instances lookup-instance! lookup-overlapping-instances
          reduce-context type-reduce-context
          (for-template @%superclasses-key))
 
 ;; ---------------------------------------------------------------------------------------------------
-;; instance contexts
+;; classes
 
-(struct class:info (vars method-table default-methods superclasses deriving-transformer) #:transparent
+(struct functional-dependency (determiners determined) #:transparent
+  #:property prop:custom-write
+  (make-constructor-style-printer
+   (λ (fundep) 'functional-dependency)
+   (λ (fundep) (list (free-id-set->list (functional-dependency-determiners fundep))
+                     (free-id-set->list (functional-dependency-determined fundep))))))
+
+(struct class:info
+  (vars                    ; class variable identifiers, in order; may appear free in method types
+   method-table            ; identifier table that maps method names to method types
+   default-methods         ; identifier table that maps method names to default implementations
+   superclasses            ; list of superclass constraints instances must satisfy
+   functional-dependencies ; set of dependencies between class parameters
+   candidate-keys          ; set of minimal sets of parameters that determine all other parameters
+   deriving-transformer)   ; syntax transformer used for deriving this class, or #f
+  #:transparent
   #:property prop:procedure
   (λ (info stx)
     ((make-variable-like-transformer
@@ -45,7 +70,78 @@
                         [id:id #'id]
                         [(id:id . _) #'id])))
      stx)))
-(struct class:instance (class vars subgoals ts dict-expr) #:transparent)
+
+(define/contract (make-class:info vars method-table default-methods superclasses
+                                  functional-dependencies deriving-transformer)
+  (-> (listof identifier?)
+      immutable-free-id-table?
+      immutable-free-id-table?
+      (listof constr?)
+      (immutable-set/c functional-dependency?)
+      (or/c (-> syntax? syntax?) #f)
+      class:info?)
+  (class:info vars method-table default-methods superclasses functional-dependencies
+              (compute-candidate-keys (immutable-free-id-set vars) functional-dependencies)
+              deriving-transformer))
+
+; Computes the closure of a set of attributes with respect to a set of functional dependencies. That
+; it, given a set of functional dependencies, computes which parameters of a class can be determined
+; from a set of known parameters.
+;
+; For example, given a class, C a b c, and a set of functional dependencies, a -> b, b -> c, then the
+; closure of {a} is {a, b, c}, the closure of {b} is {b, c}, and the closure of {c} is {c}.
+(define/contract (compute-functional-dependency-closure attrs fundeps)
+  (-> immutable-free-id-set? (immutable-set/c functional-dependency?) immutable-free-id-set?)
+  (let loop ([closure attrs])
+    (define closure*
+      (for/fold ([closure closure])
+                ([fundep (in-set fundeps)])
+        (if (for/and ([x (in-free-id-set (functional-dependency-determiners fundep))])
+              (free-id-set-member? closure x))
+            (for/fold ([closure closure])
+                      ([x (in-free-id-set (functional-dependency-determined fundep))])
+              (free-id-set-add closure x))
+            closure)))
+    (if (> (free-id-set-count closure*)
+           (free-id-set-count closure))
+        (loop closure*)
+        closure*)))
+
+; Computes the set of candidate keys for a set of attributes, given a set of functional dependencies.
+; A candidate key is a minimal set of attributes from which all attributes can be derived. In the
+; context of typeclasses, this corresponds to the sets of class parameters that can fully determine an
+; instance.
+(define/contract (compute-candidate-keys attrs fundeps)
+  (-> immutable-free-id-set?
+      (immutable-set/c functional-dependency?)
+      (immutable-set/c immutable-free-id-set?))
+  (define (minimize attrs)
+    (let ([closure (compute-functional-dependency-closure (immutable-free-id-set attrs) fundeps)])
+      (let loop ([attrs attrs]
+                 [keep '()])
+        (if (empty? attrs)
+            (immutable-free-id-set keep)
+            (let* ([attrs* (rest attrs)]
+                   [closure* (compute-functional-dependency-closure
+                              (immutable-free-id-set (append attrs* keep))
+                              fundeps)])
+              (if (free-id-set=? closure closure*)
+                  (loop attrs* keep)
+                  (loop attrs* (cons (first attrs) keep))))))))
+  (for/set ([attrs (in-permutations (free-id-set->list attrs))])
+    (minimize attrs)))
+
+;; ---------------------------------------------------------------------------------------------------
+;; instances
+
+(struct class:instance (class-id vars subgoals ts dict-expr) #:transparent)
+
+(define/contract (class:instance->string v)
+  (-> class:instance? string?)
+  (with-syntax ([class-id (class:instance-class-id v)]
+                [[var ...] (class:instance-vars v)]
+                [[t ...] (class:instance-ts v)])
+    (type->string #'(?#%type:forall* [var ...] (?#%type:app* (#%type:con class-id) t ...)))))
 
 (define-syntax-class (class-id #:require-deriving-transformer? [require-deriving-transformer? #f])
   #:description "class id"
@@ -72,8 +168,228 @@
 
 (define (current-instances-of-class class)
   (-> class:info? (listof class:instance?))
-  (filter #{eq? class (class:instance-class %)} (current-class-instances)))
+  (filter #{eq? class (syntax-local-value (class:instance-class-id %))} (current-class-instances)))
 
+(module superclasses-key racket/base
+  (require (for-syntax racket/base))
+  (provide @%superclasses-key)
+  (define-syntax (@%superclasses-key stx)
+    (raise-syntax-error #f "cannot be used as an expression" stx)))
+(require (for-template 'superclasses-key))
+
+(define/contract constr->class-id+info+ts
+  (-> constr? (values identifier? class:info? (listof type?)))
+  (syntax-parser
+    #:context 'constr->class:info
+    #:literal-sets [type-literals]
+    [(~#%type:app* (#%type:con class-id:class-id) ts ...)
+     (values #'class-id (attribute class-id.local-value) (attribute ts))]))
+
+; Given a constraint, calculate the instances it brings in scope, including instances that can be
+; derived via superclasses. For example, the constraint (Monad m) brings in three instances, one for
+; Monad and two for Functor and Applicative.
+(define/contract (constr->instances constr dict-expr)
+  (-> constr? syntax? (listof class:instance?))
+  (let-values ([(class-id class-info ts) (constr->class-id+info+ts constr)])
+    (let* ([ts* (map apply-current-subst ts)]
+           [instance (class:instance class-id '() '() ts* dict-expr)]
+           ; instantiate the superclass constraints, so for (Monad Unit), we get (Applicative Unit)
+           ; instead of (Applicative m)
+           [insts-dict (map cons (class:info-vars class-info) ts*)]
+           [super-constrs (map #{insts % insts-dict} (class:info-superclasses class-info))]
+           [superclass-dict-expr #`(free-id-table-ref #,dict-expr #'@%superclasses-key)]
+           [super-instances (for/list ([(super-constr i) (in-indexed (in-list super-constrs))])
+                              (constr->instances
+                               super-constr
+                               #`(vector-ref #,superclass-dict-expr '#,i)))])
+      (cons instance (append* super-instances)))))
+
+; Checks if any declared instances of the given class would overlap if a new instance were declared
+; with the given instance head.
+(define/contract (lookup-overlapping-instances class head)
+  (-> class:info? (listof type?) (listof class:instance?))
+  (for/fold ([result '()]
+             #:result (reverse result))
+            ([instance (in-list (current-instances-of-class class))])
+    (if (instances-overlap? (class:info-vars class)
+                            (class:info-candidate-keys class)
+                            head
+                            (class:instance-ts instance))
+        (cons instance result)
+        result)))
+
+; Checks if two instance heads overlap, using the class’s candidate keys to determine which parts of
+; the head may match. Quantified variables in the heads should not be instantiated; this function
+; assumes any such variables will be free in the heads.
+(define/contract (instances-overlap? class-vars candidate-keys head-a head-b)
+  (-> (listof identifier?)
+      (immutable-set/c immutable-free-id-set?)
+      (listof type?)
+      (listof type?)
+      boolean?)
+  (for/or ([candidate-key (in-set candidate-keys)])
+    (for/and ([class-var (in-list class-vars)]
+              [ta (in-list head-a)]
+              [tb (in-list head-b)]
+              #:when (free-id-set-member? candidate-key class-var))
+      (let loop ([ta ta] [tb tb])
+        (or (type=? ta tb)
+            (syntax-parse (list ta tb)
+              #:literal-sets [type-literals]
+              [[_:id _] #t]
+              [[_ _:id] #t]
+              [[(#%type:app a b) (#%type:app c d)]
+               (and (loop #'a #'c)
+                    (loop #'b #'d))]
+              [[_ _] #f]))))))
+
+;; ---------------------------------------------------------------------------------------------------
+;; instance lookup / constraint solving
+
+; During elaboration, Hackett performs constraint solving, which involves selecting a typeclass
+; instance that matches each constraint and inserting the relevant dictionary into the program in the
+; appropriate place. An instance can be made available one of two ways:
+;
+;   1. Module-level instance declarations provide globally-applicable instances. These are what users
+;      usually think about when they reason about typeclass instances, since they provide the actual
+;      definitions of typeclass behavior, and they are always written explicitly by the user in the
+;      source program.
+;
+;      Instance declarations may have subgoals, which require additional constraints to be solved.
+;      For example, solving (Show (Maybe a)) requires solving (Show a). Importantly, however, the
+;      solvability of subgoals never has any effect on which instance is selected! An instance is
+;      chosen and committed to without considering subgoals; if a subgoal later fails to solve, the
+;      constraint solver does NOT backtrack. This is important for both performance (needing to be
+;      able to unwind the solver at any point in time would be expensive) and for keeping constraint
+;      solving predictable (it makes it easier to detect and prevent overlapping instances).
+;
+;   2. Polymorphic values may provide local instances. These are values that include typeclass
+;      constraints in their type signatures, such as (forall [f] (Applicative f) => (f Unit)). These
+;      values are transformed into functions that accept a dictionary as an argument and use it to
+;      perform dynamic dispatch, so that dictionary is available inside the implementation of the
+;      value. Local instances never have subgoals.
+;
+; In both cases, constraint solving fundamentally reduces to a two-step process: looking up all
+; instances in scope for a given class, then matching the constraint against each instance’s head to
+; find which instances match. This matching process is delicate — we want to perform one-way matching,
+; not unification, since we don’t want constraint solving to specialize user’s types.
+;
+; To give an example, imagine the user writes the expression (show mempty). Since mempty has type
+; (forall [a] (Monoid a) => a), it will be instantiated with a fresh type variable, a1. This will lead
+; to the constraints (Monoid a1), from the use of mempty, and (Show a1), from the use of show, and a1
+; will never be further constrained.
+;
+; When we attempt to solve these constraints, we may examine instances such as (Monoid Unit) and
+; (Monoid String), which both apply, so we should not select either instance. This goes beyond the
+; problem of mere overlap, however, since even if one instance unambiguously applied, a user could
+; always add a new instance declaration later. We don’t want new instance declarations to change the
+; behavior of an existing program, so such an instance should be rejected out of hand.
+;
+; Functional dependencies add a small twist to the above rule, since fundeps may indeed introduce new
+; unifications during the constraint solving process. When solving a constraint like
+; (Monad-Reader t1 (-> String)), we can pick the (forall [r] (Monad-Reader r (-> r)) instance even
+; though it requires solving t1 to String, since instance selection is weakened by the functional
+; dependency between the second and first parameters of Monad-Reader. While this may seem inconsistent
+; with the principle that we avoid unifying types that come from the constraint, it is actually
+; perfectly fine: unification still only happens after we’ve already committed to an instance, so it
+; does not affect instance selection.
+
+(define/contract (lookup-instance!
+                  constr
+                  #:src src
+                  #:failure-thunk [failure-thunk #f])
+  (->* [constr? #:src syntax?]
+       [#:failure-thunk (or/c (-> any) #f)]
+       any) ; (values class:instance? (listof constr?))
+  (match-define-values [_ class ts] (constr->class-id+info+ts constr))
+  (define instance+subgoals
+    (for/or ([instance (in-list (current-instances-of-class class))])
+      (let ([constrs (unify-instance-head! (class:info-vars class)
+                                           (class:info-candidate-keys class)
+                                           ts
+                                           (class:instance-vars instance)
+                                           (class:instance-subgoals instance)
+                                           (class:instance-ts instance)
+                                           #:src src)])
+        (and constrs (list instance constrs)))))
+  (if instance+subgoals
+      (apply values instance+subgoals)
+      (if failure-thunk
+          (failure-thunk)
+          (raise-syntax-error 'typechecker
+                              (~a "could not deduce " (type->string (apply-current-subst constr)))
+                              src))))
+
+; Attempts to unify a type with an instance head with a type for the purposes of picking a typeclass.
+; If the match succeeds, it returns a list of instantiated subgoals for the instance, otherwise it
+; returns #f.
+(define/contract (unify-instance-head! class-vars class-candidate-keys constr-ts
+                                       instance-vars instance-subgoals instance-head
+                                       #:src src)
+  (-> (listof identifier?)
+      (immutable-set/c immutable-free-id-set?)
+      (listof type?)
+      (listof identifier?)
+      (listof constr?)
+      (listof (and/c type? type-mono?))
+      #:src syntax?
+      (or/c (listof constr?) #f))
+  (let* (; Start by instantiating any variables that appear in the instance and its subgoals.
+         [vars^ (generate-temporaries instance-vars)]
+         [var-subst (map #{cons %1 #`(#%type:wobbly-var #,%2)} instance-vars vars^)]
+         [head-inst (map #{insts % var-subst} instance-head)]
+         [subgoals-inst (map #{insts % var-subst} instance-subgoals)]
+         ; Next, see if the instance actually matches the types in the constraint. In the presence of
+         ; functional dependencies, not all types in the head necessarily have to match, so try the
+         ; candidate keys, instead.
+         [old-type-context (current-type-context)]
+         [matching-types (for/or ([candidate-key (in-set class-candidate-keys)])
+                           (if (for/and ([class-var (in-list class-vars)]
+                                         [t_head (in-list head-inst)]
+                                         [t_constr (in-list constr-ts)]
+                                         #:when (free-id-set-member? candidate-key class-var))
+                                 (types-match?! t_head t_constr))
+                               candidate-key
+                               (begin
+                                 (current-type-context old-type-context)
+                                 #f)))])
+    ; If the instance matched, unify the types in the head with the types in the constraint that
+    ; weren’t part of the candidate key.
+    (and matching-types
+         (begin
+           (for ([class-var (in-list class-vars)]
+                 [t_head (in-list head-inst)]
+                 [t_constr (in-list constr-ts)]
+                 #:when (not (free-id-set-member? matching-types class-var)))
+             (type<:! t_constr t_head #:src src))
+           subgoals-inst))))
+
+;; ---------------------------------------------------------------------------------------------------
+
+; Performs one-way matching to see if a type matches another one. Unlike unification, one-way matching
+; is asymmetric: it only solves wobbly variables in the first type argument, never in the second. If
+; unifying the two types would require unification in the second type, matching fails. Also, matching
+; is more restricted than unification: it never instantiates quantifiers in other type, nor does it
+; permit qualified types. If a quantifier or qualified type is encountered, matching fails.
+(define/contract (types-match?! a b)
+  (-> type? type? boolean?)
+  (syntax-parse (list (apply-current-subst a) (apply-current-subst b))
+    #:context 'types-match?!
+    #:literal-sets [type-literals]
+    [[(#%type:rigid-var x^) (#%type:rigid-var y^)]
+     #:when (free-identifier=? #'x^ #'y^)
+     #t]
+    [[(#%type:wobbly-var x^) t]
+     #:when (type-mono? #'t)
+     (type-inst-l! #'x^ #'t)
+     #t]
+    [[(#%type:con a) (#%type:con b)]
+     #:when (free-identifier=? #'a #'b)
+     #t]
+    [[(#%type:app a b) (#%type:app c d)]
+     (and (types-match?! #'a #'c) (types-match?! #'b #'d))]
+    [[_ _]
+     #f]))
 
 ;; ---------------------------------------------------------------------------------------------------
 ;; context reduction
@@ -133,7 +449,7 @@
 
 (define/contract (superclasses-entail? constr-a constr-b)
   (-> constr? constr? boolean?)
-  (match-let-values ([(class ts) (constr->class:info+ts constr-a)])
+  (match-let-values ([(_ class ts) (constr->class-id+info+ts constr-a)])
     (let* ([inst-dict (map cons (class:info-vars class) ts)]
            [supers (map #{insts % inst-dict} (class:info-superclasses class))])
       (or (ormap #{types-match?! % constr-b} supers)
@@ -172,109 +488,3 @@
      (quasisyntax/loc/props this-syntax
        (?#%type:forall* [x ...] #,(syntax/loc/props #'t_qual
                                     (?#%type:qual* [constr* ...] t))))]))
-
-;; ---------------------------------------------------------------------------------------------------
-;; instances
-
-(module superclasses-key racket/base
-  (require (for-syntax racket/base))
-  (provide @%superclasses-key)
-  (define-syntax (@%superclasses-key stx)
-    (raise-syntax-error #f "cannot be used as an expression" stx)))
-(require (for-template 'superclasses-key))
-
-(define/contract constr->class:info+ts
-  (-> constr? (values class:info? (listof type?)))
-  (syntax-parser
-    #:context 'constr->class:info
-    #:literal-sets [type-literals]
-    [(~#%type:app* (#%type:con class-id:class-id) ts ...)
-     (values (attribute class-id.local-value) (attribute ts))]))
-
-; Given a constraint, calculate the instances it brings in scope, including instances that can be
-; derived via superclasses. For example, the constraint (Monad m) brings in three instances, one for
-; Monad and two for Functor and Applicative.
-(define/contract (constr->instances constr dict-expr)
-  (-> constr? syntax? (listof class:instance?))
-  (let-values ([(class-info ts) (constr->class:info+ts constr)])
-    (let* ([ts* (map apply-current-subst ts)]
-           [instance (class:instance class-info '() '() ts* dict-expr)]
-           ; instantiate the superclass constraints, so for (Monad Unit), we get (Applicative Unit)
-           ; instead of (Applicative m)
-           [insts-dict (map cons (class:info-vars class-info) ts*)]
-           [super-constrs (map #{insts % insts-dict} (class:info-superclasses class-info))]
-           [superclass-dict-expr #`(free-id-table-ref #,dict-expr #'@%superclasses-key)]
-           [super-instances (for/list ([(super-constr i) (in-indexed (in-list super-constrs))])
-                              (constr->instances
-                               super-constr
-                               #`(vector-ref #,superclass-dict-expr '#,i)))])
-      (cons instance (append* super-instances)))))
-
-; Attempts to unify a type with an instance head with a type for the purposes of picking a typeclass.
-; If the match succeeds, it returns a list of instantiated subgoals for the instance, otherwise it
-; returns #f.
-(define/contract (unify-instance-head ts vars subgoals head)
-  (-> (listof type?) (listof identifier?) (listof constr?) (listof (and/c type? type-mono?))
-      (or/c (listof constr?) #f))
-  (let* ([vars^ (generate-temporaries vars)]
-         [var-subst (map #{cons %1 #`(#%type:wobbly-var #,%2)} vars vars^)]
-         [head-inst (map #{insts % var-subst} head)]
-         [subgoals-inst (map #{insts % var-subst} subgoals)])
-    (and (andmap types-match?! head-inst ts)
-         subgoals-inst)))
-
-(define/contract (lookup-instance!
-                  constr
-                  #:src src
-                  #:failure-thunk [failure-thunk
-                                   (λ ()
-                                     (raise-syntax-error
-                                      'typechecker
-                                      (~a "could not deduce "
-                                          (type->string (apply-current-subst constr)))
-                                      src))])
-  (->* [constr? #:src syntax?]
-       [#:failure-thunk (-> any)]
-       any) ; (values class:instance? (listof constr?))
-  (define-values [class ts] (constr->class:info+ts constr))
-  (define ts* (map apply-current-subst ts))
-  (define instance+subgoals
-    (for/or ([instance (in-list (current-instances-of-class class))])
-      (let ([old-type-context (current-type-context)])
-        (let ([constrs (unify-instance-head ts*
-                                            (class:instance-vars instance)
-                                            (class:instance-subgoals instance)
-                                            (class:instance-ts instance))])
-          (if constrs (list instance constrs)
-              (begin (current-type-context old-type-context) #f))))))
-  (if instance+subgoals
-      (apply values instance+subgoals)
-      (failure-thunk)))
-
-;; ---------------------------------------------------------------------------------------------------
-
-; Performs one-way unification to see if a type matches another one. Unlike general unification,
-; one-way matching is asymmetric: it only solves wobbly variables in the first type argument, never in
-; the second. If unifying the two types would require unification in the second type, matching fails.
-; Also, matching is more restricted than unification: it never instantiates quantifiers in other type,
-; nor does it permit qualified types. If a quantifier or qualified type is encountered, matching
-; fails.
-(define/contract (types-match?! a b)
-  (-> type? type? boolean?)
-  (syntax-parse (list (apply-current-subst a) (apply-current-subst b))
-    #:context 'match-types!
-    #:literal-sets [type-literals]
-    [[(#%type:rigid-var x^) (#%type:rigid-var y^)]
-     #:when (free-identifier=? #'x^ #'y^)
-     #t]
-    [[(#%type:wobbly-var x^) t]
-     #:when (type-mono? #'t)
-     (type-inst-l! #'x^ #'t)
-     #t]
-    [[(#%type:con a) (#%type:con b)]
-     #:when (free-identifier=? #'a #'b)
-     #t]
-    [[(#%type:app a b) (#%type:app c d)]
-     (and (types-match?! #'a #'c) (types-match?! #'b #'d))]
-    [[_ _]
-     #f]))

--- a/hackett-lib/hackett/private/util/contract.rkt
+++ b/hackett-lib/hackett/private/util/contract.rkt
@@ -1,0 +1,9 @@
+#lang racket/base
+
+(require racket/contract
+         racket/set)
+
+(provide (contract-out [immutable-set/c (-> contract? contract?)]))
+
+(define (immutable-set/c elem/c)
+  (set/c #:kind 'immutable elem/c))

--- a/hackett-lib/info.rkt
+++ b/hackett-lib/info.rkt
@@ -3,7 +3,7 @@
 (define collection 'multi)
 
 (define deps
-  '(["base" #:version "6.90.0.30"]
+  '(["base" #:version "7.0.0.2"]
     "curly-fn-lib"
     "data-lib"
     "syntax-classes-lib"

--- a/hackett-test/tests/hackett/integration/fundeps-arithmetic.rkt
+++ b/hackett-test/tests/hackett/integration/fundeps-arithmetic.rkt
@@ -1,0 +1,38 @@
+#lang hackett
+
+(require hackett/private/test)
+
+(data (Proxy t) Proxy)
+
+(data Z)
+(data (S n))
+
+(defn sub1/Nat : (forall [n] {(Proxy (S n)) -> (Proxy n)})
+  [[_] Proxy])
+
+(class (Reify-Nat n)
+  [reify-nat : {(Proxy n) -> Integer}])
+(instance (Reify-Nat Z)
+  [reify-nat (λ [_] 0)])
+(instance (forall [n] (Reify-Nat n) => (Reify-Nat (S n)))
+  [reify-nat (λ [p] {1 + (reify-nat (sub1/Nat p))})])
+
+(class (Add a b c) #:fundeps [[a b -> c]])
+(instance (forall [a] (Add Z a a)))
+(instance (forall [a b c] (Add a b c) => (Add (S a) b (S c))))
+
+(class (Fib a b) #:fundeps [[a -> b]])
+(instance (Fib Z Z))
+(instance (Fib (S Z) (S Z)))
+(instance (forall [a b c d] (Fib a b) (Fib (S a) c) (Add b c d) => (Fib (S (S a)) d)))
+
+(defn fib : (forall [a b] (Fib a b) => {(Proxy a) -> (Proxy b)})
+  [[_] Proxy])
+
+(test {(reify-nat (fib {Proxy : (Proxy Z)})) ==! 0})
+(test {(reify-nat (fib {Proxy : (Proxy (S Z))})) ==! 1})
+(test {(reify-nat (fib {Proxy : (Proxy (S (S Z)))})) ==! 1})
+(test {(reify-nat (fib {Proxy : (Proxy (S (S (S Z))))})) ==! 2})
+(test {(reify-nat (fib {Proxy : (Proxy (S (S (S (S Z)))))})) ==! 3})
+(test {(reify-nat (fib {Proxy : (Proxy (S (S (S (S (S Z))))))})) ==! 5})
+(test {(reify-nat (fib {Proxy : (Proxy (S (S (S (S (S (S Z)))))))})) ==! 8})


### PR DESCRIPTION
This pull request rewrites Hackett’s elaborator to use a new, multi-pass expansion strategy, then uses that functionality to implement functional dependencies. This involves a reorganization of the implementation of Hackett’s instance lookup, as well as a first stab at overlapping instance detection to ensure fundep consistency.

This pull request cannot be merged as-is because it depends on unmerged changes to the Racket macroexpander. As of this writing, the necessary changes exist on my branch [lexi-lambda/racket@local-expand-only-stops](https://github.com/lexi-lambda/racket/tree/local-expand-only-stops); I will open a pull request soon to discuss whether or not those changes can be merged as-is.

@AlexKnauth and @iitalics, I’m not sure if either of you (or anyone else) are interested in the contents of this change, but if you are, now would be a good time to take a look.