### PR TITLE
Add a missing syntax-track-origin

### DIFF
--- a/hackett-lib/hackett/private/type-language.rkt
+++ b/hackett-lib/hackett/private/type-language.rkt
@@ -124,9 +124,10 @@
              #:with x- (local-expand #'x 'expression '())
              #:attr expansion #'x-
              #:attr scoped-binding-ctxs '()
-             #:attr residual (syntax-property #'(values)
-                                              'disappeared-use
-                                              (syntax-local-introduce #'x-))]
+             #:attr residual (~> #'(values)
+                                 (syntax-property 'disappeared-use
+                                                  (syntax-local-introduce #'x-))
+                                 (syntax-track-origin #'expansion #'x))]
     [pattern (head:#%expression ~! {~var a (type intdef-ctx)})
              #:attr expansion (syntax-track-origin #'a.expansion this-syntax #'head)
              #:attr scoped-binding-ctxs '()


### PR DESCRIPTION
This adds a call to `syntax-track-origin` to a place where it was missing in type-language.rkt.

In the case where a type macro expands to an identifier, the `disappeared-use` and `origin` etc. properties on that result identifier were being lost. This copies those properties onto the `residual` syntax object.

A simple program that this PR fixes is this:
```racket
#lang hackett

(require (only-in racket/base module quote))

(module m racket
  (provide m)
  (require syntax/parse/define)
  (define-syntax-parser m
    [(m x y)
     (syntax-property #'x
                      'disappeared-use
                      (syntax-local-introduce #'y))]))

(require (for-type 'm))

(def f : (∀ [x y] (m x y))  ; before: this `y` doesn't get an arrow
  (todo!))                  ; after: this `y` is properly shown as bound to the `y` in the forall
```