### PR TITLE
 Add `⋮` declarations for val definitions 

### DIFF
--- a/hackett-lib/hackett/private/base.rkt
+++ b/hackett-lib/hackett/private/base.rkt
@@ -483,6 +483,9 @@
   #:literals [:]
   [(_ x:id/binding-declaration e:expr)
    #:with x- #'x.internal-id
+   ;; if x- is already defined, move on to the case where
+   ;; this is treated as a new definition
+   #:when (not (identifier-binding #'x-))
    (syntax-property
     #`(define- x-
         (: #,((attribute x.scoped-binding-introducer) #'e)

--- a/hackett-lib/hackett/private/kernel.rkt
+++ b/hackett-lib/hackett/private/kernel.rkt
@@ -20,7 +20,7 @@
                      [λ lambda])
          #%require/only-types combine-in except-in only-in prefix-in rename-in
          provide combine-out except-out prefix-out rename-out for-type module+
-         : def λ let letrec todo!
+         : ⋮ def λ let letrec todo!
          (for-type #:no-introduce ∀ -> => Integer Double String
                    (rename-out [@%top #%top]
                                [#%type:app #%app]

--- a/hackett-lib/info.rkt
+++ b/hackett-lib/info.rkt
@@ -7,6 +7,7 @@
     "curly-fn-lib"
     "data-lib"
     "syntax-classes-lib"
-    "threading-lib"))
+    "threading-lib"
+    "serialize-syntax-introducer"))
 (define build-deps
   '())

--- a/hackett-test/tests/hackett/integration/id-decl.rkt
+++ b/hackett-test/tests/hackett/integration/id-decl.rkt
@@ -1,0 +1,22 @@
+#lang hackett
+
+(require hackett/private/test)
+
+(⋮ f {Integer -> Integer})
+(def f (λ [x] (id x)))
+
+(⋮ fact {Integer -> Integer})
+(defn fact 
+  [[0] 1]
+  [[n] {n * (fact {n - 1})}])
+
+(⋮ id (forall [a] {a -> a}))
+(defn id
+  [[x] (: x a)])
+
+(⋮ rmt (forall [a b] (Monoid b) => (Either a b)))
+(def rmt (Right (: mempty b)))
+
+(test {rmt ==! (: (Right "") (Either Unit String))})
+(test {rmt ==! (: (Right Nil) (Either Bool (List Integer)))})
+


### PR DESCRIPTION
This pull request adds the `⋮` form, which behaves like the `:` form in Typed Racket, or like the declaration variant of the `::` form in Haskell. A Program like
```racket
(⋮ x τ)
(def x e)
```
is like this Haskell program,
```haskell
x :: τ
x = e
```
which defines `x` with type `τ` to be equal to the value produced by `e`. It typechecks `e` with `τ` as the expected type just like if you wrote `(def x : τ e)`.

This is similar to #74, but uses a different name so that `:` can be the expression variant even in "ambiguous" positions such as the REPL.