### PR TITLE
Add missing link to "pattern" in the document

### DIFF
--- a/hackett-doc/scribblings/hackett/guide.scrbl
+++ b/hackett-doc/scribblings/hackett/guide.scrbl
@@ -402,7 +402,7 @@ enumeration, we would like to be able to @emph{do something} with its values. Fo
 wish to write a function that determines if a weekday is a weekend—that is, if it is @racket[sunday]
 or @racket[saturday]. To do this, we need some way to check if a weekday is a particular value.
 
-We can do this by using @italic{pattern matching}, which makes it possible to make a decision based on
+We can do this by using @deftech[#:key "pattern"]{pattern matching}, which makes it possible to make a decision based on
 the different values of an enumeration. Here’s one way to write our @racket[is-weekend?] function:
 
 @(hackett-interaction

--- a/hackett-doc/scribblings/hackett/reference.scrbl
+++ b/hackett-doc/scribblings/hackett/reference.scrbl
@@ -307,7 +307,7 @@ contains the provided values.
   (Foo2 "hello")
   Foo3)
 
-Additionally, the bound @racket[value-id]s and @racket[data-constructor-id]s serve as @tech{patterns}
+Additionally, the bound @racket[value-id]s and @racket[data-constructor-id]s serve as @tech[#:key "pattern"]{patterns}
 that match against different values of the defined type. The pattern associated with each
 @racket[data-constuctor-id] accepts patterns that match against the contained values, so
 pattern-matching allows extracting values stored “inside” data constructors.


### PR DESCRIPTION
The `deftech` form for pattern matching is missing.