### PR TITLE
Fix typo in definition of operator or

### DIFF
--- a/hackett-doc/scribblings/hackett/reference.scrbl
+++ b/hackett-doc/scribblings/hackett/reference.scrbl
@@ -573,7 +573,7 @@ used higher-order if desired.
   (eval:check (if True "first" "second") "first")
   (eval:check (if False "first" "second") "second"))}
 
-@defthing[\|\| {t:Bool t:-> t:Bool t:-> t:Bool}]{
+@defthing[|| {t:Bool t:-> t:Bool t:-> t:Bool}]{
 
 Returns @racket[True] if its first argument is @racket[True]; otherwise, returns its second argument.
 Notably, the second argument will not be evaluated at all if the first argument is @racket[True], but


### PR DESCRIPTION
On the documentation page: [https://lexi-lambda.github.io/hackett/reference-datatypes.html#%28def._%28%28lib._hackett%2Fmain..rkt%29._~7c~7c%29%29](https://lexi-lambda.github.io/hackett/reference-datatypes.html#%28def._%28%28lib._hackett%2Fmain..rkt%29._~7c~7c%29%29)
the `||`s in the examples look right with the backslash escapes, but the  backslashes in the title render wrong