### PR TITLE
Accessibility: mention required Racket version and supply shell.nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Here’s some sample Hackett code that demonstrates some of Hackett’s features
 
 To reiterate: **Hackett is extremely experimental right now.** Things are not guaranteed to work correctly (or work at all), and things are likely to change dramatically. If you really want to install Hackett to play around with it, though, you can.
 
-You will need to have Racket installed to use Hackett. Using `raco`, you can install Hackett as a package:
+You will need to have Racket v6 installed to use Hackett. Using `raco`, you can install Hackett as a package:
 
 ```
 $ raco pkg install hackett
@@ -69,3 +69,9 @@ Now you can use Hackett by writing `#lang hackett` at the top of a file.
 
 [hackett-docs]: https://lexi-lambda.github.io/hackett/
 [types-as-macros]: http://www.ccs.neu.edu/home/stchang/pubs/ckg-popl2017.pdf
+
+### Nix
+
+Since Racket v6 is quite old, `shell.nix` is provided for convenience. Use `nix-shell` to enter shell with Racket v6.12.
+
+> To install Nix, use either [official](https://nixos.org/download/) or [modernized](https://determinate.systems/posts/determinate-nix-installer/) installer.

--- a/README.md
+++ b/README.md
@@ -75,3 +75,5 @@ Now you can use Hackett by writing `#lang hackett` at the top of a file.
 Since Racket v6 is quite old, `shell.nix` is provided for convenience. Use `nix-shell` to enter shell with Racket v6.12.
 
 > To install Nix, use either [official](https://nixos.org/download/) or [modernized](https://determinate.systems/posts/determinate-nix-installer/) installer.
+
+> Note that you don't need this repository cloned to use the `shell.nix`. Only file itself is needed.

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,11 @@
+let
+  nixpkgs = builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/294c3605a3a57773242d8585ab1815cd61d4a65f.tar.gz";
+  };
+  pkgs = import nixpkgs {};
+in
+  pkgs.mkShell {
+    nativeBuildInputs = [
+      pkgs.racket
+    ];
+  }


### PR DESCRIPTION
Unfortunately, Hackett doesn't seem to work with Racket's two of latest major versions. To keep the project accessible to those who are interested, I've specified required Racket version and added `shell.nix` to simplify it's usage. No rebuilds needed, surprisingly! Even though this nixpkgs version is 6 years old, they seem to have kept all required dependencies in cache.

P.S. Still hope you'll return to this eventually :cry: 